### PR TITLE
Dynamic fall rate

### DIFF
--- a/client/src/scene/SceneGameArena.ts
+++ b/client/src/scene/SceneGameArena.ts
@@ -64,8 +64,10 @@ export class SceneGameArena extends Phaser.Scene {
     create() {
         this.scoreboard = new ScoreboardUI(this, this.sharedState.socket, true);
         this.spectator = new SpectatorUI(this, this.sharedState.socket);
-        this.fallRateTimer = null;
         this.controls = null;
+
+        // Initialize the fall rate to 1000 until we get confirmation from the server.
+        this.updateFallTimer(1000);
 
         // initialize an empty rendered board
         this.renderedBoard = [];
@@ -95,16 +97,17 @@ export class SceneGameArena extends Phaser.Scene {
 
         this.socket.emit("requestFallRate");
 
-        this.socket.on("updateFallRate", (fallRate) => {
-            this.updateFallTimer(fallRate);
-        });
-
         this.initListeners();
     }
 
     private initListeners() {
         // Clean out any old listeners to avoid accumulation.
         this.socket.removeListener("toSceneGameOver");
+        this.socket.removeListener("updateFallRate");
+
+        this.socket.on("updateFallRate", (fallRate) => {
+            this.updateFallTimer(fallRate);
+        });
 
         this.socket.on("toSceneGameOver", (playerPoints) => {
             this.scene.start("SceneGameOver", {

--- a/common/messages/sceneGameArena.ts
+++ b/common/messages/sceneGameArena.ts
@@ -2,7 +2,10 @@ import { ColoredScore } from "../shared";
 
 export interface ToClientEvents {
     toSceneGameOver: (data: Array<ColoredScore>) => void;
+    updateFallRate: (fallRate: number) => void;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface ToServerEvents {}
+export interface ToServerEvents {
+    requestFallRate: () => void;
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -91,6 +91,10 @@ export function broadcastHideVotingSequence() {
 export function broadcastRemainingPlayers(playersNeeded: number) {
     io.sockets.emit("updateRemainingPlayers", playersNeeded);
 }
+
+export function broadcastFallRate(fallRate: number) {
+    io.sockets.emit("updateFallRate", fallRate);
+}
 // ==============================================
 
 // Uncomment to view the game end sequence:
@@ -113,5 +117,6 @@ io.on("connection", (socket) => {
     scoreboard.initSocketListeners(socket, level);
     spectator.initSocketListeners(socket);
     queue.initSocketListeners(socket);
+    level.initSocketListeners(socket);
     // FIXME need a state machine to tell which scene the game is at, conditionally tackle disconnections?
 });

--- a/server/index.ts
+++ b/server/index.ts
@@ -71,6 +71,7 @@ export function broadcastUpdateScoreboard(msg: Array<ColoredScore>) {
 
 export function broadcastToSceneWaitingRoom() {
     queue.resetQueue();
+    level.resetLevel();
     scene.setScene("SceneWaitingRoom");
     io.sockets.emit("toSceneWaitingRoom");
 }

--- a/server/src/Level.ts
+++ b/server/src/Level.ts
@@ -32,7 +32,10 @@ export class Level {
      * @param score The total score the players have accumulated.
      */
     public checkUpdateLevel(score: number) {
-        if (score >= this._currentLevel * 20 && this._currentLevel < 15) {
+        if (
+            score - (this._currentLevel - 1) * 20 >= this._currentLevel * 20 &&
+            this._currentLevel < 15
+        ) {
             this._currentLevel++;
             this.updateFallRate();
         }

--- a/server/src/Level.ts
+++ b/server/src/Level.ts
@@ -44,7 +44,7 @@ export class Level {
     public spectatorIncreaseFallRate() {
         this.increaseFallRate();
         setTimeout(() => {
-            this.decreaseFallRate();
+            this.updateFallRate();
         }, 20000);
     }
 
@@ -54,7 +54,7 @@ export class Level {
     public spectatorDecreaseFallRate() {
         this.decreaseFallRate();
         setTimeout(() => {
-            this.increaseFallRate();
+            this.updateFallRate();
         }, 20000);
     }
 
@@ -70,7 +70,7 @@ export class Level {
     }
 
     /**
-     * Increase the fall rate.
+     * Increase the fall rate to be the next-level's equivalent.
      */
     private increaseFallRate() {
         this.currentFallRate =
@@ -79,7 +79,7 @@ export class Level {
     }
 
     /**
-     * Decrease the fall rate.
+     * Decrease the fall rate to be the previous level's equivalent.
      */
     private decreaseFallRate() {
         this.currentFallRate =

--- a/server/src/Level.ts
+++ b/server/src/Level.ts
@@ -7,7 +7,6 @@ type SocketLevel = Socket<ToServerEvents, ToClientEvents>;
 export class Level {
     private _currentLevel: number;
     private currentFallRate: number;
-    private MAX_FALL_RATE: number = 200;
 
     constructor() {
         this._currentLevel = 1;
@@ -29,11 +28,11 @@ export class Level {
     }
 
     /**
-     * Check if its possible to update the game's level based off the given score.
+     * Check if its possible to update the game's level based off the given score. Max level is 15.
      * @param score The total score the players have accumulated.
      */
     public checkUpdateLevel(score: number) {
-        if (score >= this._currentLevel * 20) {
+        if (score >= this._currentLevel * 20 && this._currentLevel < 15) {
             this._currentLevel++;
             this.increaseFallRate();
         }
@@ -60,23 +59,24 @@ export class Level {
     }
 
     /**
-     * Increase the fall rate by 50ms.
+     * Increase the fall rate according to the current level.
      */
     private increaseFallRate() {
-        if (this.currentFallRate - 50 >= this.MAX_FALL_RATE) {
-            this.currentFallRate -= 50;
-        } else {
-            this.currentFallRate = 200;
-        }
-
+        this.currentFallRate =
+            1000 *
+            (0.8 * ((this._currentLevel - 1) * 0.007)) **
+                (this._currentLevel - 1);
         broadcastFallRate(this.currentFallRate);
     }
 
     /**
-     * Decrease the fall rate by 50ms.
+     * Decrease the fall rate according to the current level.
      */
     private decreaseFallRate() {
-        this.currentFallRate += 50;
+        this.currentFallRate =
+            1000 *
+            (0.8 * ((this._currentLevel - 2) * 0.007)) **
+                (this._currentLevel - 2);
         broadcastFallRate(this.currentFallRate);
     }
 

--- a/server/src/Level.ts
+++ b/server/src/Level.ts
@@ -90,6 +90,14 @@ export class Level {
     }
 
     /**
+     * Reset the values of the fallrate & level. Used upon restarting the game.
+     */
+    public resetLevel() {
+        this.currentFallRate = 1000;
+        this._currentLevel = 1;
+    }
+
+    /**
      * Notify the client of the current fallrate.
      * @param socket The client requesting data.
      */

--- a/server/src/Level.ts
+++ b/server/src/Level.ts
@@ -34,7 +34,7 @@ export class Level {
     public checkUpdateLevel(score: number) {
         if (score >= this._currentLevel * 20 && this._currentLevel < 15) {
             this._currentLevel++;
-            this.increaseFallRate();
+            this.updateFallRate();
         }
     }
 
@@ -59,9 +59,9 @@ export class Level {
     }
 
     /**
-     * Increase the fall rate according to the current level.
+     * Update the fall rate according to the current level.
      */
-    private increaseFallRate() {
+    private updateFallRate() {
         this.currentFallRate =
             1000 *
             (0.8 * ((this._currentLevel - 1) * 0.007)) **
@@ -70,7 +70,16 @@ export class Level {
     }
 
     /**
-     * Decrease the fall rate according to the current level.
+     * Increase the fall rate.
+     */
+    private increaseFallRate() {
+        this.currentFallRate =
+            1000 * (0.8 * (this._currentLevel * 0.007)) ** this._currentLevel;
+        broadcastFallRate(this.currentFallRate);
+    }
+
+    /**
+     * Decrease the fall rate.
      */
     private decreaseFallRate() {
         this.currentFallRate =

--- a/server/src/Level.ts
+++ b/server/src/Level.ts
@@ -30,15 +30,15 @@ export class Level {
     /**
      * Check if its possible to update the game's level based off the given score. Max level is 15.
      * @param score The total score the players have accumulated.
+     * @returns Whether the level was incremented.
      */
     public checkUpdateLevel(score: number) {
-        if (
-            score - (this._currentLevel - 1) * 20 >= this._currentLevel * 20 &&
-            this._currentLevel < 15
-        ) {
+        if (score >= this._currentLevel * 20 && this._currentLevel < 15) {
             this._currentLevel++;
             this.updateFallRate();
+            return true;
         }
+        return false;
     }
 
     /**

--- a/server/src/Level.ts
+++ b/server/src/Level.ts
@@ -1,36 +1,90 @@
+import { ToServerEvents, ToClientEvents } from "common/messages/sceneGameArena";
+import { broadcastFallRate } from "../index";
+import { Socket } from "socket.io";
+
+type SocketLevel = Socket<ToServerEvents, ToClientEvents>;
+
 export class Level {
     private _currentLevel: number;
+    private currentFallRate: number;
+    private MAX_FALL_RATE: number = 200;
 
     constructor() {
         this._currentLevel = 1;
+        this.currentFallRate = 1000;
     }
 
     get currentLevel(): number {
         return this._currentLevel;
     }
 
+    /**
+     * Setup listeners for the current client socket.
+     * @param socket The client's socket.
+     */
+    public initSocketListeners(socket: SocketLevel) {
+        socket.on("requestFallRate", () => {
+            socket.emit("updateFallRate", this.currentFallRate);
+        });
+    }
+
+    /**
+     * Check if its possible to update the game's level based off the given score.
+     * @param score The total score the players have accumulated.
+     */
     public checkUpdateLevel(score: number) {
         if (score >= this._currentLevel * 20) {
             this._currentLevel++;
-            // FIXME: Increase block fall rate.
+            this.increaseFallRate();
         }
     }
 
-    public spectatorIncrementLevel() {
-        this._currentLevel++;
-        // FIXME: Increase block fall rate.
+    /**
+     * Increase the fall rate due to spectator voting.
+     */
+    public spectatorIncreaseFallRate() {
+        this.increaseFallRate();
         setTimeout(() => {
-            this._currentLevel--;
-            // FIXME: Decrease block fall rate.
+            this.decreaseFallRate();
         }, 20000);
     }
 
-    public spectatorDecrementLevel() {
-        this._currentLevel--;
-        // FIXME: Decrease block fall rate.
+    /**
+     * Decrease the fall rate due to spectator voting.
+     */
+    public spectatorDecreaseFallRate() {
+        this.decreaseFallRate();
         setTimeout(() => {
-            this._currentLevel++;
-            // FIXME: Increase block fall rate.
+            this.increaseFallRate();
         }, 20000);
+    }
+
+    /**
+     * Increase the fall rate by 50ms.
+     */
+    private increaseFallRate() {
+        if (this.currentFallRate - 50 >= this.MAX_FALL_RATE) {
+            this.currentFallRate -= 50;
+        } else {
+            this.currentFallRate = 200;
+        }
+
+        broadcastFallRate(this.currentFallRate);
+    }
+
+    /**
+     * Decrease the fall rate by 50ms.
+     */
+    private decreaseFallRate() {
+        this.currentFallRate += 50;
+        broadcastFallRate(this.currentFallRate);
+    }
+
+    /**
+     * Notify the client of the current fallrate.
+     * @param socket The client requesting data.
+     */
+    public getFallRate(socket: SocketLevel) {
+        socket.emit("updateFallRate", this.currentFallRate);
     }
 }

--- a/server/src/Scoreboard.ts
+++ b/server/src/Scoreboard.ts
@@ -17,7 +17,7 @@ export class Scoreboard {
     private _greenScore: number;
     private _pinkScore: number;
     private _blueScore: number;
-    private _totalScore: number;
+    private _accumulatedScore: number;
     private _scoreMap: Array<ColoredScore>;
     private _finalScores: Array<ColoredScore>;
 
@@ -26,7 +26,7 @@ export class Scoreboard {
         this._greenScore = 0;
         this._pinkScore = 0;
         this._blueScore = 0;
-        this._totalScore = 0;
+        this._accumulatedScore = 0;
 
         this._finalScores = [];
 
@@ -85,10 +85,6 @@ export class Scoreboard {
         return this._blueScore;
     }
 
-    get totalScore(): number {
-        return this._totalScore;
-    }
-
     get currentTeamScore(): number {
         return (
             this._orangeScore +
@@ -114,7 +110,7 @@ export class Scoreboard {
         this._greenScore = 0;
         this._pinkScore = 0;
         this._blueScore = 0;
-        this._totalScore = 0;
+        this._accumulatedScore = 0;
     }
 
     /**
@@ -124,7 +120,7 @@ export class Scoreboard {
      * @param level The level object. Used to *possibly* increase the level of the game.
      */
     public incrementScore(playerIndex: number, value: number, level: Level) {
-        this._totalScore += value;
+        this._accumulatedScore += value;
 
         switch (playerIndex) {
             case PlayerColor.Orange:
@@ -141,7 +137,11 @@ export class Scoreboard {
                 break;
         }
 
-        level.checkUpdateLevel(this.totalScore);
+        // Reset the score if the level was incremented.
+        if (level.checkUpdateLevel(this._accumulatedScore)) {
+            this._accumulatedScore = 0;
+        }
+
         this.updateScoreboardUI(level.currentLevel);
     }
 

--- a/server/src/Spectator.ts
+++ b/server/src/Spectator.ts
@@ -209,7 +209,7 @@ export class Spectator {
                 if (this._isFirstRoundVoting) {
                     this.generateSecondVotingSequence("fallRate", level);
                 } else if (this._previouslyVotedOption == "option1") {
-                    level.spectatorIncrementLevel();
+                    level.spectatorIncreaseFallRate();
                     console.log("Incrementing level (fall rate)"); // FIXME: remove later.
                 } else if (this._previouslyVotedOption == "option2") {
                     console.log("Spawning in tetromino option 1..."); // FIXME: Need to spawn in a tetromino for the players for 20 seconds.
@@ -222,7 +222,7 @@ export class Spectator {
                         level
                     );
                 } else if (this._previouslyVotedOption == "option1") {
-                    level.spectatorDecrementLevel();
+                    level.spectatorDecreaseFallRate();
                     console.log("Decrementing level (fall rate)"); // FIXME: remove later.
                 } else if (this._previouslyVotedOption == "option2") {
                     console.log("Spawning in tetromino option 2 ..."); // FIXME: Spawn in tetrominos for players for 20 seconds.


### PR DESCRIPTION
Dynamic fall rate based off current level & spectator voting.
Max level is set to be 15.

Upon loading into SceneGameArena, the client will request the current fall rate from the server. Once the value is received, the timer will be modified on the client and the blocks will fall at the new value.

I was wondering if this may cause sync issues across the different clients but with the "source of truth" being worked on, Idk how much of an issue that actually is.