### PR TITLE
Implement placing a tetromino

### DIFF
--- a/client/src/GameState.ts
+++ b/client/src/GameState.ts
@@ -20,6 +20,7 @@ export class GameState {
     // synced from server, ordered by increasing, circular player numbers
     // i.e. if you are player 1, these are of player 2, then 3, then 0
     otherPieces: Array<Tetromino>;
+    deadReckoningSystem!: DeadReckoningSystem;
     playerId!: 0 | 1 | 2 | 3;
 
     private blankBoard() {
@@ -49,16 +50,77 @@ export class GameState {
             new Tetromino(TetrominoType.T),
         ];
 
+        // initial rotation
+        this.otherPieces.map((tetro, i) => {
+            tetro.setRotatedPosition(tetro.rawPosition, i + 1);
+            tetro.setRotation(i + 1);
+        });
+
         this.socket.on("initPlayer", (playerId) => {
             this.playerId = playerId;
             console.log("playerId: ", playerId);
+
+            this.deadReckoningSystem = new DeadReckoningSystem(
+                this.otherPieces
+            );
         });
 
         this.socket.on("playerMove", (playerId, state) => {
             const i = (3 - this.playerId + playerId) % 4; // Circular distance
+            this.otherPieces[i].rawPosition = state.position; // position before rotation
+            this.deadReckoningSystem.refreshLastAppearance(i); // tell the system that the piece has moved, restart the timer
+
             this.otherPieces[i].setType(state.type);
             this.otherPieces[i].setRotatedPosition(state.position, i + 1);
             this.otherPieces[i].setRotation(i + 1 + state.rotation);
         });
+    }
+}
+
+class DeadReckoningSystem {
+    private static readonly FALL_INTERVAL = 1000; // 1 second in ms
+    // local timestamp of last appearance of each player, in ms
+    private lastAppearances!: Array<number>;
+    private tetros: Array<Tetromino>;
+    constructor(tetros: Array<Tetromino>) {
+        this.tetros = tetros;
+    }
+
+    initTimer() {
+        const now = new Date().getTime();
+        this.lastAppearances = [now, now, now];
+        console.log("init, lastAppearances: ", this.lastAppearances);
+    }
+
+    updateRemotePlayersIfDead(board: Array<Array<TetrominoType | null>>) {
+        const tetros: Array<Tetromino> = [];
+        const now = new Date().getTime();
+        for (let i = 0; i < 3; i++) {
+            // for each remote tetromino, see if they have not updated for at least FALL_INTERVAL
+            // if so and it can still fall: call fall and rotate
+            const lastAppearance = this.lastAppearances[i];
+            const reckonedTetro = this.tetros[i];
+            if (now - lastAppearance > DeadReckoningSystem.FALL_INTERVAL) {
+                const didMove = reckonedTetro.moveIfCan(
+                    board,
+                    (reckonedTetro) => {
+                        reckonedTetro.rawPosition[0] += 1;
+                        // rotate
+                        reckonedTetro.setRotatedPosition(
+                            reckonedTetro.rawPosition,
+                            i + 1
+                        );
+                        reckonedTetro.setRotation(i + 1);
+                    }
+                );
+                this.lastAppearances[i] = now;
+            }
+        }
+        return tetros;
+    }
+
+    // update the last appearance of the player
+    refreshLastAppearance(i: number) {
+        this.lastAppearances[i] = new Date().getTime();
     }
 }

--- a/client/src/GameState.ts
+++ b/client/src/GameState.ts
@@ -51,7 +51,7 @@ export class GameState {
 
         // initial rotation
         this.otherPieces.map((tetro, i) => {
-            tetro.setRotatedPosition(tetro.rawPosition, i + 1);
+            tetro.setRotatedPosition(tetro.position, i + 1);
             tetro.setRotation(i + 1);
         });
 
@@ -61,7 +61,7 @@ export class GameState {
 
         this.socket.on("playerMove", (playerId, state) => {
             const i = (3 - this.playerId + playerId) % 4; // Circular distance
-            this.otherPieces[i].rawPosition = state.position; // position before rotation
+            this.otherPieces[i].position = state.position; // position before rotation
             this.otherPieces[i].setType(state.type);
             this.otherPieces[i].setRotatedPosition(state.position, i + 1);
             this.otherPieces[i].setRotation(i + 1 + state.rotation);

--- a/client/src/GameState.ts
+++ b/client/src/GameState.ts
@@ -20,7 +20,6 @@ export class GameState {
     // synced from server, ordered by increasing, circular player numbers
     // i.e. if you are player 1, these are of player 2, then 3, then 0
     otherPieces: Array<Tetromino>;
-    deadReckoningSystem!: DeadReckoningSystem;
     playerId!: 0 | 1 | 2 | 3;
 
     private blankBoard() {
@@ -58,69 +57,36 @@ export class GameState {
 
         this.socket.on("initPlayer", (playerId) => {
             this.playerId = playerId;
-            console.log("playerId: ", playerId);
-
-            this.deadReckoningSystem = new DeadReckoningSystem(
-                this.otherPieces
-            );
         });
 
         this.socket.on("playerMove", (playerId, state) => {
             const i = (3 - this.playerId + playerId) % 4; // Circular distance
             this.otherPieces[i].rawPosition = state.position; // position before rotation
-            this.deadReckoningSystem.refreshLastAppearance(i); // tell the system that the piece has moved, restart the timer
-
             this.otherPieces[i].setType(state.type);
             this.otherPieces[i].setRotatedPosition(state.position, i + 1);
             this.otherPieces[i].setRotation(i + 1 + state.rotation);
         });
-    }
-}
 
-class DeadReckoningSystem {
-    private static readonly FALL_INTERVAL = 1000; // 1 second in ms
-    // local timestamp of last appearance of each player, in ms
-    private lastAppearances!: Array<number>;
-    private tetros: Array<Tetromino>;
-    constructor(tetros: Array<Tetromino>) {
-        this.tetros = tetros;
-    }
-
-    initTimer() {
-        const now = new Date().getTime();
-        this.lastAppearances = [now, now, now];
-        console.log("init, lastAppearances: ", this.lastAppearances);
-    }
-
-    updateRemotePlayersIfDead(board: Array<Array<TetrominoType | null>>) {
-        const tetros: Array<Tetromino> = [];
-        const now = new Date().getTime();
-        for (let i = 0; i < 3; i++) {
-            // for each remote tetromino, see if they have not updated for at least FALL_INTERVAL
-            // if so and it can still fall: call fall and rotate
-            const lastAppearance = this.lastAppearances[i];
-            const reckonedTetro = this.tetros[i];
-            if (now - lastAppearance > DeadReckoningSystem.FALL_INTERVAL) {
-                const didMove = reckonedTetro.moveIfCan(
-                    board,
-                    (reckonedTetro) => {
-                        reckonedTetro.rawPosition[0] += 1;
-                        // rotate
-                        reckonedTetro.setRotatedPosition(
-                            reckonedTetro.rawPosition,
-                            i + 1
-                        );
-                        reckonedTetro.setRotation(i + 1);
-                    }
-                );
-                this.lastAppearances[i] = now;
+        this.socket.on("playerPlace", (playerId, state) => {
+            if (playerId == this.playerId) {
+                // the placing event is emitted by this very client, who already handled the local board during emitting
+                return;
             }
-        }
-        return tetros;
-    }
 
-    // update the last appearance of the player
-    refreshLastAppearance(i: number) {
-        this.lastAppearances[i] = new Date().getTime();
+            // place the tetro on our board
+            const i = (3 - this.playerId + playerId) % 4; // Circular distance
+            const tetroToPlace = Tetromino.createFromState(state);
+            // local rotate
+            tetroToPlace.setRotation(i + 1 + tetroToPlace.rotation);
+            tetroToPlace.setRotatedPosition(tetroToPlace.position, i + 1);
+            // place on frozen board
+            tetroToPlace.tiles.forEach((tile) => {
+                const [row, col] = [
+                    tetroToPlace.position[0] + tile[0],
+                    tetroToPlace.position[1] + tile[1],
+                ];
+                this.frozenBoard[row][col] = tetroToPlace.type;
+            });
+        });
     }
 }

--- a/client/src/Tetromino.ts
+++ b/client/src/Tetromino.ts
@@ -123,12 +123,23 @@ export class Tetromino {
         };
     }
 
-    static createFromState(state: TetrominoState): Tetromino {
-        const newTetro = new Tetromino(state.type);
-        newTetro.position = state.position;
-        newTetro.tiles = cloneDeep(Tetromino.shapes[state.type].tiles);
-        newTetro.rotation = state.rotation;
-        return newTetro;
+    static createFromState(
+        state: TetrominoState,
+        ccRotations: number
+    ): Tetromino {
+        const tetromino = new Tetromino(state.type);
+        Tetromino.updateFromState(tetromino, state, ccRotations);
+        return tetromino;
+    }
+
+    static updateFromState(
+        tetromino: Tetromino,
+        state: TetrominoState,
+        ccRotations: number
+    ) {
+        tetromino.setType(state.type);
+        tetromino.setRotatedPosition(state.position, ccRotations);
+        tetromino.setRotation(ccRotations + state.rotation);
     }
 
     setType(type: TetrominoType) {
@@ -171,12 +182,12 @@ export class Tetromino {
         this.rotation = <0 | 1 | 2 | 3>(rotation % 4);
     }
 
-    rotateCW() {
-        this.setRotation(this.rotation + 1);
+    static rotateCW(tetromino: Tetromino) {
+        tetromino.setRotation(tetromino.rotation + 1);
     }
 
-    rotateCCW() {
-        this.setRotation(4 + this.rotation - 1);
+    static rotateCCW(tetromino: Tetromino) {
+        tetromino.setRotation(4 + tetromino.rotation + 1);
     }
 
     moveIfCan(

--- a/client/src/Tetromino.ts
+++ b/client/src/Tetromino.ts
@@ -171,35 +171,12 @@ export class Tetromino {
         this.rotation = <0 | 1 | 2 | 3>(rotation % 4);
     }
 
-    // TODO: Properly verify movement is possible before allowing it
-    move(colDelta: number): boolean {
-        const newCol = this.position[1] + colDelta;
-        if (newCol < 0 || newCol >= BOARD_SIZE) {
-            return false;
-        }
-        this.position[1] = newCol;
-        return true;
-    }
-
-    // TODO: Verify rotation is possible before allowing it
-    private canRotate(): boolean {
-        return true;
-    }
-
-    rotateCW(): boolean {
-        if (!this.canRotate()) {
-            return false;
-        }
+    rotateCW() {
         this.setRotation(this.rotation + 1);
-        return true;
     }
 
-    rotateCCW(): boolean {
-        if (!this.canRotate()) {
-            return false;
-        }
+    rotateCCW() {
         this.setRotation(4 + this.rotation - 1);
-        return true;
     }
 
     moveIfCan(
@@ -223,6 +200,7 @@ export class Tetromino {
                     null &&
                 // AND 2. the tiles are NOT from the old self
                 // TODO falling out of bounds
+                // TODO hitting outside the visible arena (game over)
                 !oldTileCoords.some(
                     ([oldRow, oldCol]) =>
                         newTetro.position[0] + row == oldRow &&

--- a/client/src/Tetromino.ts
+++ b/client/src/Tetromino.ts
@@ -128,6 +128,14 @@ export class Tetromino {
         };
     }
 
+    static createFromState(state: TetrominoState): Tetromino {
+        const newTetro = new Tetromino(state.type);
+        newTetro.position = state.position;
+        newTetro.tiles = cloneDeep(Tetromino.shapes[state.type].tiles);
+        newTetro.rotation = state.rotation;
+        return newTetro;
+    }
+
     setType(type: TetrominoType) {
         if (this.type == type) {
             return;

--- a/client/src/Tetromino.ts
+++ b/client/src/Tetromino.ts
@@ -115,21 +115,12 @@ export class Tetromino {
         this.rotation = 0; // default (no rotation)
     }
 
-    reportPosition(): TetrominoState {
+    reportState(): TetrominoState {
         return {
             type: this.type,
             position: this.position,
             rotation: this.rotation,
         };
-    }
-
-    static createFromState(
-        state: TetrominoState,
-        ccRotations: number
-    ): Tetromino {
-        const tetromino = new Tetromino(state.type);
-        Tetromino.updateFromState(tetromino, state, ccRotations);
-        return tetromino;
     }
 
     static updateFromState(

--- a/client/src/Tetromino.ts
+++ b/client/src/Tetromino.ts
@@ -202,20 +202,6 @@ export class Tetromino {
         return true;
     }
 
-    canTetroFall(board: Array<Array<TetrominoType | null>>): boolean {
-        // if the blocks right below this tetro are all empty, it can fall.
-        const bottomRelative = Math.max(...this.tiles.map((tile) => tile[0])); // the lowest block in the tetro tiles, ranging from 0-3
-        const bottomAbsolute = this.position[0] + bottomRelative; // the row of which the lowest block of the tetro is at in the board
-
-        if (bottomAbsolute + 1 >= board.length) return false;
-
-        return this.tiles.every(
-            (tile: any) =>
-                tile[0] < bottomRelative || // either the tile is not the bottom tiles which we don't care
-                board[bottomAbsolute + 1][this.position[1] + tile[1]] == null // or the room below it has to be empty
-        );
-    }
-
     moveIfCan(
         board: Array<Array<TetrominoType | null>>,
         movement: (tetro: Tetromino) => Tetromino | void

--- a/client/src/Tetromino.ts
+++ b/client/src/Tetromino.ts
@@ -205,19 +205,18 @@ export class Tetromino {
         for (let i = 0; i < this.tiles.length; i++) {
             const [row, col] = newTetro.tiles[i];
 
-            if (
-                // 1. the new position has some other tiles in it
+            // conditions to check if there is something there already
+            // there is a tile already
+            const tileIsOccupied =
                 board[newTetro.position[0] + row][newTetro.position[1] + col] !=
-                    null &&
-                // AND 2. the tiles are NOT from the old self
-                // TODO falling out of bounds
-                // TODO hitting outside the visible arena (game over)
-                !oldTileCoords.some(
-                    ([oldRow, oldCol]) =>
-                        newTetro.position[0] + row == oldRow &&
-                        newTetro.position[1] + col == oldCol
-                )
-            ) {
+                null;
+            // the tile is not part of the old tetromino
+            const tileIsForeign = !oldTileCoords.some(
+                ([oldRow, oldCol]) =>
+                    newTetro.position[0] + row == oldRow &&
+                    newTetro.position[1] + col == oldCol
+            );
+            if (tileIsOccupied && tileIsForeign) {
                 return false;
             }
         }

--- a/client/src/Tetromino.ts
+++ b/client/src/Tetromino.ts
@@ -102,7 +102,6 @@ export class Tetromino {
 
     type: TetrominoType;
     position: [number, number];
-    rawPosition: [number, number];
     rotation: 0 | 1 | 2 | 3;
     tiles: Array<[number, number]>;
 
@@ -110,10 +109,6 @@ export class Tetromino {
         this.type = type;
         this.tiles = cloneDeep(Tetromino.shapes[type].tiles);
         this.position = [
-            0,
-            Math.round((BOARD_SIZE - Tetromino.shapes[type].width) / 2),
-        ];
-        this.rawPosition = [
             0,
             Math.round((BOARD_SIZE - Tetromino.shapes[type].width) / 2),
         ];
@@ -256,7 +251,6 @@ export class Tetromino {
         this.tiles = newTetro.tiles;
         this.rotation = newTetro.rotation;
         this.type = newTetro.type;
-        this.rawPosition = newTetro.rawPosition;
         return true;
     }
 }

--- a/client/src/Tetromino.ts
+++ b/client/src/Tetromino.ts
@@ -190,6 +190,18 @@ export class Tetromino {
         tetromino.setRotation(4 + tetromino.rotation + 1);
     }
 
+    static fall(tetromino: Tetromino) {
+        // fall down by 1
+        tetromino.position[0] += 1;
+    }
+
+    static slide(direction: -1 | 1): (tetro: Tetromino) => void {
+        // move left/right by 1
+        return (tetromino) => {
+            tetromino.position[1] += direction;
+        };
+    }
+
     moveIfCan(
         board: Array<Array<TetrominoType | null>>,
         movement: (tetro: Tetromino) => Tetromino | void

--- a/client/src/scene/SceneGameArena.ts
+++ b/client/src/scene/SceneGameArena.ts
@@ -97,7 +97,7 @@ export class SceneGameArena extends Phaser.Scene {
         this.otherTetros = [];
         for (let i = 0; i < 3; i++) {
             this.otherTetros.push(
-                new RenderedTetromino(this.gameState.otherPieces[i])
+                new RenderedTetromino(this.gameState.otherTetrominoes[i])
             );
         }
 
@@ -128,7 +128,7 @@ export class SceneGameArena extends Phaser.Scene {
 
         // 12 fps
         if (this.frameTimeElapsed > 1000 / this.FRAMERATE) {
-            this.updateBoardFromFrozen(this, this.gameState.otherPieces);
+            this.updateBoardFromFrozen(this, this.gameState.otherTetrominoes);
             this.updateUserInput(this);
             this.updateDrawBoard(this.gameState, this);
             this.updateDrawPlayer(this);
@@ -178,16 +178,12 @@ export class SceneGameArena extends Phaser.Scene {
         } else if (scene.keys.q.isDown || scene.keys.z.isDown) {
             moved = scene.gameState.currentTetromino.moveIfCan(
                 scene.gameState.board,
-                (tetro) => {
-                    tetro.rotateCCW();
-                }
+                Tetromino.rotateCCW
             );
         } else if (scene.keys.e.isDown || scene.keys.x.isDown) {
             moved = scene.gameState.currentTetromino.moveIfCan(
                 scene.gameState.board,
-                (tetro) => {
-                    tetro.rotateCW();
-                }
+                Tetromino.rotateCW
             );
         }
 
@@ -235,9 +231,6 @@ export class SceneGameArena extends Phaser.Scene {
         if (
             tetro.moveIfCan(board, (tetro) => {
                 tetro.position[0] += 1;
-                if (tetro.position[0] > BOARD_SIZE) {
-                    tetro.position[0] = 0;
-                }
                 return tetro;
             })
         ) {

--- a/client/src/scene/SceneGameArena.ts
+++ b/client/src/scene/SceneGameArena.ts
@@ -187,7 +187,7 @@ export class SceneGameArena extends Phaser.Scene {
             scene.gameState.socket.emit(
                 "playerMove",
                 scene.gameState.playerId,
-                scene.gameState.currentTetromino.reportPosition()
+                scene.gameState.currentTetromino.reportState()
             );
         }
     }
@@ -228,14 +228,14 @@ export class SceneGameArena extends Phaser.Scene {
             scene.gameState.socket.emit(
                 "playerMove",
                 scene.gameState.playerId,
-                scene.gameState.currentTetromino.reportPosition()
+                scene.gameState.currentTetromino.reportState()
             );
         } else {
             // place on state.board and emit events to the server
             scene.gameState.socket.emit(
                 "playerPlace",
                 scene.gameState.playerId,
-                scene.gameState.currentTetromino.reportPosition()
+                scene.gameState.currentTetromino.reportState()
             );
 
             // convert the tetromino to static blocks
@@ -257,7 +257,7 @@ export class SceneGameArena extends Phaser.Scene {
             scene.gameState.socket.emit(
                 "playerMove",
                 scene.gameState.playerId,
-                scene.gameState.currentTetromino.reportPosition()
+                scene.gameState.currentTetromino.reportState()
             );
         }
     }

--- a/client/src/scene/SceneGameArena.ts
+++ b/client/src/scene/SceneGameArena.ts
@@ -261,6 +261,13 @@ export class SceneGameArena extends Phaser.Scene {
             this.currentTetro = new RenderedTetromino(
                 scene.gameState.currentTetromino
             );
+
+            // broadcast new tetromino position
+            scene.gameState.socket.emit(
+                "playerMove",
+                scene.gameState.playerId,
+                scene.gameState.currentTetromino.reportPosition()
+            );
         }
     }
 }

--- a/client/src/scene/SceneGameArena.ts
+++ b/client/src/scene/SceneGameArena.ts
@@ -164,16 +164,12 @@ export class SceneGameArena extends Phaser.Scene {
         if (scene.keys.a.isDown || scene.keys.left.isDown) {
             moved = scene.gameState.currentTetromino.moveIfCan(
                 scene.gameState.board,
-                (tetro) => {
-                    tetro.position[1] -= 1;
-                }
+                Tetromino.slide(-1) // left
             );
         } else if (scene.keys.d.isDown || scene.keys.right.isDown) {
             moved = scene.gameState.currentTetromino.moveIfCan(
                 scene.gameState.board,
-                (tetro) => {
-                    tetro.position[1] += 1;
-                }
+                Tetromino.slide(1) // right
             );
         } else if (scene.keys.q.isDown || scene.keys.z.isDown) {
             moved = scene.gameState.currentTetromino.moveIfCan(
@@ -228,12 +224,7 @@ export class SceneGameArena extends Phaser.Scene {
         const board = state.board;
         const tetro = state.currentTetromino;
 
-        if (
-            tetro.moveIfCan(board, (tetro) => {
-                tetro.position[0] += 1;
-                return tetro;
-            })
-        ) {
+        if (tetro.moveIfCan(board, Tetromino.fall)) {
             scene.gameState.socket.emit(
                 "playerMove",
                 scene.gameState.playerId,

--- a/server/index.ts
+++ b/server/index.ts
@@ -123,8 +123,5 @@ io.on("connection", (socket) => {
         socket.broadcast.emit("playerPlace", ...args);
     });
 
-    scoreboard.initSocketListeners(socket, level);
-    spectator.initSocketListeners(socket);
-    queue.initSocketListeners(socket);
     // FIXME need a state machine to tell which scene the game is at, conditionally tackle disconnections?
 });

--- a/server/index.ts
+++ b/server/index.ts
@@ -109,6 +109,10 @@ io.on("connection", (socket) => {
     socket.on("playerMove", (...args) => {
         socket.broadcast.emit("playerMove", ...args);
     });
+    socket.on("playerPlace", (...args) => {
+        console.log("player ", args[0], " placed.");
+        socket.broadcast.emit("playerPlace", ...args);
+    });
 
     scoreboard.initSocketListeners(socket, level);
     spectator.initSocketListeners(socket);


### PR DESCRIPTION
closes #14

## Flow of events and renderings

Consider p1 (the left screen) is falling down; p2 (the player view on the right screen), on p1's right, is falling to its left. p1's future path is about to be blocked by p2. ![image](https://user-images.githubusercontent.com/25297856/157155736-40231644-116e-4d30-a33e-d738244b61f8.png)
- p2 falls through, finding nothing in its path of falling.
- p1 tries to fall, only to find out p2 is there, it is now PLACED.
    - p1 **emits** "playerPlaced".
    - p1 freezes the tetromino onto the board, it is part of the static blocks now.
    - p1 re-initialize its tetromino to fall from the top again.
    - p1 re-renders the board.
    - p2 **receives** "playerPlaced".
    - p2 calculates where the placed tetromino is.
    - p2 puts it on its local board, and re-render.

## source of truth
As the flow describes, source of truth is scattered to each of the players (no source of truth). so is the board update. That is, if the player does not receive an emitted "placed" event, its board won't have that placed tetromino. I'm remotely thinking about a periodical update of the full board (placed, frozen blocks), but that is not 100% related to placing. 
