### PR TITLE
Remove SharedState and use scene-specific data types.

### DIFF
--- a/client/src/index.ts
+++ b/client/src/index.ts
@@ -1,16 +1,11 @@
 import Phaser from "phaser";
-import { io, Socket } from "socket.io-client";
+import { io } from "socket.io-client";
 
 import { SceneWaitingRoom } from "./scene/SceneWaitingRoom";
 import { SceneGameArena } from "./scene/SceneGameArena";
 import { SceneGameOver } from "./scene/SceneGameOver";
 import { GameState } from "./GameState";
 import { BOARD_SIZE, TILE_SIZE } from "common/shared";
-
-export interface SharedState {
-    gameState: GameState;
-    socket: Socket;
-}
 
 const config = {
     type: Phaser.AUTO,

--- a/client/src/scene/SceneGameOver.ts
+++ b/client/src/scene/SceneGameOver.ts
@@ -1,17 +1,22 @@
 import Phaser from "phaser";
 import { Socket } from "socket.io-client";
-import { SharedState } from "..";
+import { GameState } from "../GameState";
 import { ScoreboardUI } from "./ScoreboardUI";
 
 import { ToClientEvents, ToServerEvents } from "common/messages/sceneGameOver";
 import { ColoredScore } from "common/shared";
 
 type SocketGameOver = Socket<ToClientEvents, ToServerEvents>;
-type SceneDataGameOver = SharedState & { playerPoints: Array<ColoredScore> };
+
+interface SceneDataGameOver {
+    gameState: GameState;
+    playerPoints: Array<ColoredScore>;
+}
+
 export class SceneGameOver extends Phaser.Scene {
     private playerData!: Array<ColoredScore>;
     private scoreboard!: ScoreboardUI;
-    private sharedData!: SharedState;
+    private gameState!: GameState;
     private socket!: SocketGameOver;
 
     constructor() {
@@ -19,9 +24,9 @@ export class SceneGameOver extends Phaser.Scene {
     }
 
     init(data: SceneDataGameOver) {
-        this.sharedData = data;
+        this.gameState = data.gameState;
         this.playerData = data.playerPoints;
-        this.socket = data.socket;
+        this.socket = this.gameState.socket;
     }
 
     create() {
@@ -33,7 +38,7 @@ export class SceneGameOver extends Phaser.Scene {
         this.socket.removeListener("toSceneWaitingRoom");
 
         this.socket.on("toSceneWaitingRoom", () => {
-            this.scene.start("SceneWaitingRoom", { ...this.sharedData });
+            this.scene.start("SceneWaitingRoom", { gameState: this.gameState });
         });
     }
 }

--- a/client/src/scene/SceneWaitingRoom.ts
+++ b/client/src/scene/SceneWaitingRoom.ts
@@ -1,6 +1,5 @@
 import Phaser from "phaser";
-import { BOARD_SIZE } from "common/shared";
-import { SharedState } from "..";
+import { BOARD_SIZE, ColoredScore } from "common/shared";
 import { Socket } from "socket.io-client";
 
 import {
@@ -8,25 +7,30 @@ import {
     ToServerEvents,
 } from "common/messages/sceneWaitingRoom";
 import { WebFontFile } from "../plugins/WebFontFile";
+import { GameState } from "../GameState";
 
 import TitleScreen from "../assets/TitleScreen.svg";
 
 type SocketWaitingRoom = Socket<ToClientEvents, ToServerEvents>;
+
+interface SceneDataWaitingRoom {
+    gameState: GameState;
+}
 
 export class SceneWaitingRoom extends Phaser.Scene {
     private playersNeededText!: Phaser.GameObjects.Text;
     private headerText!: Phaser.GameObjects.Text;
     private button!: Phaser.GameObjects.Text;
     private socket!: SocketWaitingRoom;
-    private sharedData!: SharedState;
+    private gameState!: GameState;
 
     constructor() {
         super("SceneWaitingRoom");
     }
 
-    init(data: SharedState) {
-        this.sharedData = data;
-        this.socket = data.socket;
+    init(data: SceneDataWaitingRoom) {
+        this.gameState = data.gameState;
+        this.socket = this.gameState.socket;
     }
 
     preload() {
@@ -114,13 +118,13 @@ export class SceneWaitingRoom extends Phaser.Scene {
         });
 
         this.socket.on("toSceneGameArena", () => {
-            this.scene.start("SceneGameArena", { ...this.sharedData });
+            this.scene.start("SceneGameArena", { gameState: this.gameState });
         });
 
         this.socket.on("toSceneGameOver", (playerPoints) => {
             this.scene.start("SceneGameOver", {
-                ...this.sharedData,
-                playerPoints: playerPoints,
+                gameState: this.gameState,
+                playerPoints,
             });
         });
     }

--- a/client/src/scene/SpectatorUI.ts
+++ b/client/src/scene/SpectatorUI.ts
@@ -77,7 +77,7 @@ export class SpectatorUI {
 
         this.socket.on("showVotingSequence", (votingSequence) => {
             // Only display the voting sequence for spectators.
-            if (this.scene.sharedState.gameState.playerId == null) {
+            if (this.scene.gameState.playerId == null) {
                 this.generateTimedEvent(votingSequence);
             }
         });


### PR DESCRIPTION
But unlike socket.io, phaser3 does not provide the type checks when it takes in the data. (`scene.start()` does not have warnings if data doesn't match the interface). But at least there is a reference inside each scene in terms of what it expects from its calling scenes.