### PR TITLE
Implement player2player collision. Refactor `moveIfCan`.

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -8,9 +8,7 @@
     "test": "vitest"
   },
   "dependencies": {
-    "@types/lodash": "^4.14.178",
     "common": "file:../common",
-    "lodash": "^4.17.21",
     "phaser": "^3.53.1",
     "socket.io": "^4.4.1",
     "socket.io-client": "^4.4.1",

--- a/client/src/GameState.ts
+++ b/client/src/GameState.ts
@@ -177,17 +177,29 @@ export class GameState {
         tetro: Tetromino,
         tetrominoes: Array<Tetromino>
     ): boolean {
-        // No out of bounds check because overlapWithPlayers doesn't index board
-        const expandedSet = new Set(tetro.tiles);
-        tetro.tiles.forEach(([row, col]) => {
-            expandedSet.add([row + 1, col]);
-            expandedSet.add([row - 1, col]);
-            expandedSet.add([row, col + 1]);
-            expandedSet.add([row, col - 1]);
-        });
-
         const lookahead = tetro.toTetrominoLookahead();
-        lookahead.tiles = Array.from(expandedSet);
+        lookahead.tiles = tetro.tiles
+            // insert tiles and their expanded positions
+            // No out of bounds check because overlapWithPlayers doesn't index board
+            .map(([row, col]) => {
+                return [
+                    [row, col],
+                    [row + 1, col],
+                    [row - 1, col],
+                    [row, col + 1],
+                    [row, col - 1],
+                ];
+            })
+            // flatten
+            .reduce((total, current) => [...total, ...current])
+            // deduplicate
+            .filter(
+                (tile, index, tiles) =>
+                    tiles.findIndex(
+                        ([row, col]) => row === tile[0] && col === tile[1]
+                    ) === index
+            ) as [number, number][];
+
         // if the expanded tetromino is overlapping, then it's definitely adjacent, if not actually overlapping. (We don't have to care about excluding the actually overlapped case because that handles more scenarios when synchronization is not ideal.)
         return this.overlapWithPlayers(lookahead, tetrominoes);
     }

--- a/client/src/GameState.ts
+++ b/client/src/GameState.ts
@@ -3,6 +3,7 @@ import { TetrominoType } from "common/TetrominoType";
 import { Tetromino } from "./Tetromino";
 import { BOARD_SIZE } from "common/shared";
 import { ToServerEvents, ToClientEvents } from "common/messages/game";
+import { cloneDeep } from "lodash";
 
 type GameSocket = Socket<ToClientEvents, ToServerEvents>;
 
@@ -68,18 +69,44 @@ export class GameState {
         });
 
         this.socket.on("playerPlace", (playerId, state) => {
-            if (playerId == this.playerId) {
-                // the placing event is emitted by this very client, who already handled the local board during emitting
-                return;
-            }
-
             // place the tetro on our board
             const i = this.getPlayerIndex(playerId);
             const tetroToPlace = this.otherTetrominoes[i];
-
             Tetromino.updateFromState(tetroToPlace, state, i + 1);
             this.placeTetromino(tetroToPlace);
+            this.otherTetrominoes[i] = tetroToPlace;
+
+            // if the other tetromino is bumping into us, freeze ours too.
+            if (
+                this.adjacentWithPlayers(this.currentTetromino, [
+                    this.otherTetrominoes[i],
+                ])
+            ) {
+                this.emitAndPlaceCurrentTetromino();
+            }
         });
+    }
+
+    public emitPlayerMove() {
+        this.socket.emit(
+            "playerMove",
+            this.playerId,
+            this.currentTetromino.reportState()
+        );
+    }
+
+    public emitAndPlaceCurrentTetromino() {
+        // place on board and emit events to the server
+        this.socket.emit(
+            "playerPlace",
+            this.playerId,
+            this.currentTetromino.reportState()
+        );
+        this.placeTetromino(this.currentTetromino);
+        // start a new tetromino from the top
+        this.currentTetromino.respawn();
+        // broadcast new tetromino position
+        this.emitPlayerMove();
     }
 
     public placeTetromino(tetromino: Tetromino) {
@@ -90,5 +117,150 @@ export class GameState {
             ];
             this.board[row][col] = tetromino.type;
         });
+    }
+
+    public moveIfCan(
+        movement: (tetro: Tetromino) => Tetromino | void
+    ): boolean {
+        let newTetro: Tetromino = cloneDeep(this.currentTetromino);
+
+        // look-ahead for the next tetromino state after movement
+        newTetro = movement(newTetro) || newTetro;
+
+        if (
+            this.overlapWithBoard(newTetro, this.currentTetromino) ||
+            this.overlapWithPlayers(newTetro, this.otherTetrominoes)
+        ) {
+            return false;
+        }
+
+        this.currentTetromino.position = newTetro.position;
+        this.currentTetromino.tiles = newTetro.tiles;
+        this.currentTetromino.rotation = newTetro.rotation;
+        this.currentTetromino.type = newTetro.type;
+        return true;
+    }
+
+    /**
+     * check against static board, see if newTetro is overlapping with static monominoes placed on board
+     * @returns boolean - if `newTetro` overlaps with any blocks on the board
+     */
+    private overlapWithBoard(
+        newTetro: Tetromino,
+        oldTetro: Tetromino
+    ): boolean {
+        const oldTileCoords = oldTetro.tiles.map((tile) => [
+            oldTetro.position[0] + tile[0],
+            oldTetro.position[1] + tile[1],
+        ]);
+        for (let i = 0; i < newTetro.tiles.length; i++) {
+            const [row, col] = newTetro.tiles[i];
+
+            // conditions to check if there is something there already
+            // there is a tile already
+            const tileIsOccupied =
+                this.board[newTetro.position[0] + row][
+                    newTetro.position[1] + col
+                ] != null;
+
+            // the tile is not part of the old tetromino
+            const tileIsForeign = !oldTileCoords.some(
+                ([oldRow, oldCol]) =>
+                    newTetro.position[0] + row == oldRow &&
+                    newTetro.position[1] + col == oldCol
+            );
+            if (tileIsOccupied && tileIsForeign) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * check against other players' tetrominoes: see if newTetro is overlapping with other existing players
+     * @returns boolean - if `newTetro` overlaps with any of the `tetrominoes`
+     */
+    private overlapWithPlayers(
+        newTetro: Tetromino,
+        tetrominoes: Array<Tetromino>
+    ): boolean {
+        const newTileCoords = newTetro.tiles.map((tile) => [
+            newTetro.position[0] + tile[0],
+            newTetro.position[1] + tile[1],
+        ]);
+
+        return tetrominoes.some((tetro) => {
+            // if the bounding boxes are more than the-maximum-"manhattan distance" away
+            const isFarAway =
+                Math.abs(tetro.position[0] - newTetro.position[0]) +
+                    Math.abs(tetro.position[1] - newTetro.position[1]) >
+                8; // 8 is twice the max width of a tetromino bounding box
+            if (isFarAway) {
+                return false;
+            }
+
+            // if newTetro has overlapping monominoes with those tetro
+            const isOverLapping = tetro.tiles
+                // get coordinates on board
+                .map((tile) => [
+                    tetro.position[0] + tile[0],
+                    tetro.position[1] + tile[1],
+                ])
+                // each of those coordinates does not overlap with newTetro's coordinates
+                .some((tileCoord) => {
+                    return newTileCoords.some(
+                        ([row, col]) =>
+                            row === tileCoord[0] && col === tileCoord[1]
+                    );
+                });
+            if (isOverLapping) {
+                return true;
+            }
+        });
+    }
+
+    /**
+     * Returns if `tetro` is adjacent to any of the tetrominoes in the `tetrominoes` list
+     * @param tetro - The tetromino that is supposedly "currentTetromino", but can be any tetromino to be tested
+     * @param tetrominoes - The array of tetrominoes to be scanned through and looked for adjacentness
+     */
+    private adjacentWithPlayers(
+        tetro: Tetromino,
+        tetrominoes: Array<Tetromino>
+    ): boolean {
+        const oldTiles = tetro.tiles;
+        const newTiles = cloneDeep(oldTiles);
+        const shapeWidth = Tetromino.shapes[tetro.type].width;
+
+        const expandedTetro = cloneDeep(tetro);
+        // expand the tetromino by 1
+        // NOTE: careful about when the position of tetro is [0, 0], the resulting calculated board coordinates will exceed matrix border. BUT, this won't happen because we block corners with walls.
+        for (let row = -1; row <= shapeWidth; row++) {
+            for (let col = -1; col <= shapeWidth; col++) {
+                if (adjacentToMonomino(row, col, oldTiles)) {
+                    newTiles.push([row, col]);
+                }
+            }
+        }
+        expandedTetro.tiles = newTiles;
+
+        // if the expanded tetromino is overlapping, then it's definitely adjacent, if not actually overlapping. (We don't have to care about excluding the actually overlapped case because that handles more scenarios when synchronization is not ideal.)
+        return this.overlapWithPlayers(expandedTetro, tetrominoes);
+
+        // Returns true if a coordinate is "adjacent" to the tiles
+        function adjacentToMonomino(
+            row: number,
+            col: number,
+            tiles: [number, number][]
+        ): boolean {
+            return tiles.some(([tileRow, tileCol]) => {
+                return (
+                    (Math.abs(row - tileRow) === 1 &&
+                        Math.abs(col - tileCol) === 0) ||
+                    (Math.abs(row - tileRow) === 0 &&
+                        Math.abs(col - tileCol) === 1)
+                );
+            });
+        }
     }
 }

--- a/client/src/RenderedTetromino.ts
+++ b/client/src/RenderedTetromino.ts
@@ -15,13 +15,9 @@ export class RenderedTetromino {
     draw(scene: Scene) {
         if (this.tileSprites) this.tileSprites.forEach((rec) => rec.destroy());
         this.tileSprites = this.inner.tiles.map(([row, col]) => {
-            // transform relative block position on top of tetromino position
-            const x = (this.inner.position[1] + col + 0.5) * TILE_SIZE;
-            const y = (this.inner.position[0] + row + 0.5) * TILE_SIZE;
-
             const rec = scene.add.rectangle(
-                x,
-                y,
+                (col + 0.5) * TILE_SIZE,
+                (row + 0.5) * TILE_SIZE,
                 TILE_SIZE,
                 TILE_SIZE,
                 0xff0000

--- a/client/src/Tetromino.ts
+++ b/client/src/Tetromino.ts
@@ -204,42 +204,4 @@ export class Tetromino {
             tetromino.position[1] += direction;
         };
     }
-
-    moveIfCan(
-        board: Array<Array<TetrominoType | null>>,
-        movement: (tetro: Tetromino) => Tetromino | void
-    ): boolean {
-        let newTetro: Tetromino = cloneDeep(this);
-        const oldTileCoords = newTetro.tiles.map((tile) => [
-            newTetro.position[0] + tile[0],
-            newTetro.position[1] + tile[1],
-        ]);
-
-        // look-ahead for the next tetromino state after movement
-        newTetro = movement(newTetro) || newTetro;
-        for (let i = 0; i < this.tiles.length; i++) {
-            const [row, col] = newTetro.tiles[i];
-
-            // conditions to check if there is something there already
-            // there is a tile already
-            const tileIsOccupied =
-                board[newTetro.position[0] + row][newTetro.position[1] + col] !=
-                null;
-            // the tile is not part of the old tetromino
-            const tileIsForeign = !oldTileCoords.some(
-                ([oldRow, oldCol]) =>
-                    newTetro.position[0] + row == oldRow &&
-                    newTetro.position[1] + col == oldCol
-            );
-            if (tileIsOccupied && tileIsForeign) {
-                return false;
-            }
-        }
-        // copy all attributes over
-        this.position = newTetro.position;
-        this.tiles = newTetro.tiles;
-        this.rotation = newTetro.rotation;
-        this.type = newTetro.type;
-        return true;
-    }
 }

--- a/client/src/Tetromino.ts
+++ b/client/src/Tetromino.ts
@@ -115,6 +115,18 @@ export class Tetromino {
         this.rotation = 0; // default (no rotation)
     }
 
+    respawn() {
+        // TODO generate from a sequence iterator (another singleton class?)
+        // use respawn instead of `new Tetromino` because right now rendered tetromino will lose reference if inner is created anew. FIXME this is not true when using extension style rendered tetromino
+        this.type = this.type | TetrominoType.T;
+        this.tiles = cloneDeep(Tetromino.shapes[this.type].tiles);
+        this.position = [
+            0,
+            Math.round((BOARD_SIZE - Tetromino.shapes[this.type].width) / 2),
+        ];
+        this.rotation = 0; // default (no rotation)
+    }
+
     reportState(): TetrominoState {
         return {
             type: this.type,

--- a/client/src/Tetromino.ts
+++ b/client/src/Tetromino.ts
@@ -1,11 +1,16 @@
 import { TetrominoType } from "common/TetrominoType";
 import { BOARD_SIZE } from "common/shared";
 import { TetrominoState } from "common/message";
-import { TetrominoLookahead } from "./GameState";
 
 type Shape = {
     width: number;
     tiles: Array<[number, number]>;
+};
+
+export type TetrominoLookahead = {
+    position: [number, number];
+    tiles: Array<[number, number]>;
+    rotation: 0 | 1 | 2 | 3;
 };
 
 export class Tetromino {
@@ -142,6 +147,20 @@ export class Tetromino {
         );
     }
 
+    updateFromLookahead(lookahead: TetrominoLookahead) {
+        this.position = lookahead.position;
+        this.tiles = lookahead.tiles;
+        this.rotation = lookahead.rotation;
+    }
+
+    toTetrominoLookahead(): TetrominoLookahead {
+        return {
+            position: [...this.position],
+            tiles: this.tiles,
+            rotation: this.rotation,
+        };
+    }
+
     setType(type: TetrominoType) {
         if (this.type == type) {
             return;
@@ -180,20 +199,6 @@ export class Tetromino {
                 offsetCol + newCol,
             ]);
         this.position = [newRow, newCol];
-    }
-
-    updateFromLookahead(lookahead: TetrominoLookahead) {
-        this.position = lookahead.position;
-        this.tiles = lookahead.tiles;
-        this.rotation = lookahead.rotation;
-    }
-
-    toTetrominoLookahead(): TetrominoLookahead {
-        return {
-            position: [...this.position],
-            tiles: this.tiles,
-            rotation: this.rotation,
-        };
     }
 
     static rotate(tetromino: Tetromino, rotation: number): TetrominoLookahead {

--- a/client/src/scene/SceneGameArena.ts
+++ b/client/src/scene/SceneGameArena.ts
@@ -152,39 +152,28 @@ export class SceneGameArena extends Phaser.Scene {
         });
     }
 
-    // TODO
-    // 1. these update functions can have unified interface
-    // 2. they have duplicate logic with the Phaser.Scene.time.addEvent, consider moving the falling down here, but we need a internal state/class instance for each of them to track time delta in order to have a different function
     private updateUserInput() {
         let moved = false;
         if (this.keys.a.isDown || this.keys.left.isDown) {
-            moved = this.gameState.currentTetromino.moveIfCan(
-                this.gameState.board,
+            moved = this.gameState.moveIfCan(
                 Tetromino.slide(-1) // left
             );
         } else if (this.keys.d.isDown || this.keys.right.isDown) {
-            moved = this.gameState.currentTetromino.moveIfCan(
-                this.gameState.board,
+            moved = this.gameState.moveIfCan(
                 Tetromino.slide(1) // right
             );
         } else if (this.keys.q.isDown || this.keys.z.isDown) {
-            moved = this.gameState.currentTetromino.moveIfCan(
-                this.gameState.board,
-                Tetromino.rotateCCW
+            moved = this.gameState.moveIfCan(
+                Tetromino.rotateCCW // counter clock wise
             );
         } else if (this.keys.e.isDown || this.keys.x.isDown) {
-            moved = this.gameState.currentTetromino.moveIfCan(
-                this.gameState.board,
-                Tetromino.rotateCW
+            moved = this.gameState.moveIfCan(
+                Tetromino.rotateCW // clock wise
             );
         }
 
         if (moved) {
-            this.gameState.socket.emit(
-                "playerMove",
-                this.gameState.playerId,
-                this.gameState.currentTetromino.reportState()
-            );
+            this.gameState.emitPlayerMove();
         }
     }
 
@@ -216,37 +205,12 @@ export class SceneGameArena extends Phaser.Scene {
     }
 
     private updateFalling() {
-        if (
-            this.gameState.currentTetromino.moveIfCan(
-                this.gameState.board,
-                Tetromino.fall
-            )
-        ) {
-            this.gameState.socket.emit(
-                "playerMove",
-                this.gameState.playerId,
-                this.gameState.currentTetromino.reportState()
-            );
+        if (this.gameState.moveIfCan(Tetromino.fall)) {
+            this.gameState.emitPlayerMove();
         } else {
-            // place on board and emit events to the server
-            this.gameState.socket.emit(
-                "playerPlace",
-                this.gameState.playerId,
-                this.gameState.currentTetromino.reportState()
-            );
-            this.gameState.placeTetromino(this.gameState.currentTetromino);
-
-            // start a new tetromino from the top
-            this.gameState.currentTetromino = new Tetromino(TetrominoType.T);
+            this.gameState.emitAndPlaceCurrentTetromino();
             this.currentTetro = new RenderedTetromino(
                 this.gameState.currentTetromino
-            );
-
-            // broadcast new tetromino position
-            this.gameState.socket.emit(
-                "playerMove",
-                this.gameState.playerId,
-                this.gameState.currentTetromino.reportState()
             );
         }
     }


### PR DESCRIPTION
- refactored `moveIfCan` from `Tetromino.ts` into `GameState.ts`, because GameState is naturally knowledgable about the board and other players.
- refactored collision detection codes a bit, there are two main check functions: `overlapWithBoard` and `overlapWithPlayers`, which are run in `moveIfCan`.
- whenever a place event comes in, `adjacentWithPlayers` is checked to see if the current player should also be placed.

see the exact moment when two neighboring tetrominoes bump into each other.
![image](https://user-images.githubusercontent.com/25297856/158085111-afefdc12-920d-4b91-997a-7f4ae660c7f3.png)


---
playerId comparison in incoming placed event is not needed.