### PR TITLE
Server Test Suite

### DIFF
--- a/client/src/scene/SceneGameArena.ts
+++ b/client/src/scene/SceneGameArena.ts
@@ -29,6 +29,7 @@ interface SceneDataGameArena {
 export class SceneGameArena extends Phaser.Scene {
     FRAMERATE: number = 12;
 
+    /* eslint-disable @typescript-eslint/no-explicit-any */
     keys!: any; // Phaser doesn't provide nice typing for keyboard.addKeys
     gameState!: GameState;
     socket!: SocketGame;

--- a/client/src/scene/SceneWaitingRoom.ts
+++ b/client/src/scene/SceneWaitingRoom.ts
@@ -1,5 +1,5 @@
 import Phaser from "phaser";
-import { BOARD_SIZE, ColoredScore } from "common/shared";
+import { BOARD_SIZE } from "common/shared";
 import { Socket } from "socket.io-client";
 
 import {

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -1,3 +1,0 @@
-// test("server test can run", () => {
-//     expect(1 + 1).toBe(2);
-// });

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -1,3 +1,3 @@
-test("server test can run", () => {
-    expect(1 + 1).toBe(2);
-});
+// test("server test can run", () => {
+//     expect(1 + 1).toBe(2);
+// });

--- a/server/index.ts
+++ b/server/index.ts
@@ -6,21 +6,12 @@ import { Level } from "./src/Level";
 import { Scoreboard } from "./src/Scoreboard";
 import { PlayerQueue } from "./src/PlayerQueue";
 import { Spectator } from "./src/Spectator";
+import { broadcast } from "./src/broadcast";
 import path from "path";
 
 import { ServerToClientEvents, ClientToServerEvents } from "common/message";
 import { ColoredScore } from "common/shared";
 import { SceneTracker } from "./src/SceneTracker";
-
-interface InterServerEvents {
-    ping: () => void;
-}
-
-interface SocketData {
-    name: string;
-    age: number;
-}
-// =================== grab from tutorial ==============
 
 // Initialize the express engine
 const app: express.Application = express();
@@ -45,63 +36,70 @@ const port = process.env.PORT || 80;
 // Server setup
 server.listen(port);
 
-const io = new Server<
-    ClientToServerEvents,
-    ServerToClientEvents,
-    InterServerEvents,
-    SocketData
->(server, {
+const io = new Server<ClientToServerEvents, ServerToClientEvents>(server, {
     cors: {
         origin: "*",
     },
 });
 
-console.log(`Server started at port ${port}`);
-let playerCounter: 0 | 1 | 2 | 3 = 0; // FIXME: Remove this on final version.
-const scoreboard = new Scoreboard();
-const level = new Level();
-const queue = new PlayerQueue();
-const spectator = new Spectator();
-const scene = new SceneTracker();
-
 // =========== Emit to all sockets ================
-export function broadcastUpdateScoreboard(msg: Array<ColoredScore>) {
+const updateScoreboard: broadcast["updateScoreboard"] = (
+    msg: Array<ColoredScore>
+) => {
     io.sockets.emit("updateScoreboard", msg);
-}
+};
 
-export function broadcastToSceneWaitingRoom() {
+const toSceneWaitingRoom: broadcast["toSceneWaitingRoom"] = () => {
     queue.resetQueue();
     level.resetLevel();
     scene.setScene("SceneWaitingRoom");
     io.sockets.emit("toSceneWaitingRoom");
-}
+};
 
-export function broadcastToSceneGameArena() {
+const toSceneGameArena: broadcast["toSceneGameArena"] = () => {
     scene.setScene("SceneGameArena");
     io.sockets.emit("toSceneGameArena");
-}
+};
 
-export function broadcastToSceneGameOver(msg: Array<ColoredScore>) {
+const toSceneGameOver: broadcast["toSceneGameOver"] = (
+    msg: Array<ColoredScore>
+) => {
     scene.setScene("SceneGameOver");
     io.sockets.emit("toSceneGameOver", msg);
-}
+};
 
-export function broadcastShowVotingSequence(votingSequence: string) {
+const showVotingSequence: broadcast["showVotingSequence"] = (
+    votingSequence: string
+) => {
     io.sockets.emit("showVotingSequence", votingSequence);
-}
+};
 
-export function broadcastHideVotingSequence() {
+const hideVotingSequence: broadcast["hideVotingSequence"] = () => {
     io.sockets.emit("hideVotingSequence");
-}
+};
 
-export function broadcastRemainingPlayers(playersNeeded: number) {
+const remainingPlayers: broadcast["remainingPlayers"] = (
+    playersNeeded: number
+) => {
     io.sockets.emit("updateRemainingPlayers", playersNeeded);
-}
+};
 
-export function broadcastFallRate(fallRate: number) {
+const broadcastFallRate: broadcast["fallRate"] = (fallRate: number) => {
     io.sockets.emit("updateFallRate", fallRate);
-}
+};
 // ==============================================
+
+console.log(`Server started at port ${port}`);
+let playerCounter: 0 | 1 | 2 | 3 = 0; // FIXME: Remove this on final version.
+const scoreboard = new Scoreboard(
+    toSceneGameOver,
+    toSceneWaitingRoom,
+    updateScoreboard
+);
+const level = new Level(broadcastFallRate);
+const queue = new PlayerQueue(remainingPlayers, toSceneGameArena);
+const spectator = new Spectator(showVotingSequence, hideVotingSequence);
+const scene = new SceneTracker();
 
 io.on("connection", (socket) => {
     scoreboard.initSocketListeners(socket, level);
@@ -128,6 +126,4 @@ io.on("connection", (socket) => {
         console.log("player ", args[0], " placed.");
         socket.broadcast.emit("playerPlace", ...args);
     });
-
-    // FIXME need a state machine to tell which scene the game is at, conditionally tackle disconnections?
 });

--- a/server/src/Level.ts
+++ b/server/src/Level.ts
@@ -6,15 +6,19 @@ type SocketLevel = Socket<ToServerEvents, ToClientEvents>;
 
 export class Level {
     private _currentLevel: number;
-    private currentFallRate: number;
+    private _currentFallRate: number;
 
     constructor() {
         this._currentLevel = 1;
-        this.currentFallRate = 1000;
+        this._currentFallRate = 1000;
     }
 
     get currentLevel(): number {
         return this._currentLevel;
+    }
+
+    get currentFallRate(): number {
+        return this._currentFallRate;
     }
 
     /**
@@ -23,7 +27,7 @@ export class Level {
      */
     public initSocketListeners(socket: SocketLevel) {
         socket.on("requestFallRate", () => {
-            socket.emit("updateFallRate", this.currentFallRate);
+            socket.emit("updateFallRate", this._currentFallRate);
         });
     }
 
@@ -65,38 +69,38 @@ export class Level {
      * Update the fall rate according to the current level.
      */
     private updateFallRate() {
-        this.currentFallRate =
+        this._currentFallRate =
             1000 *
-            (0.8 * ((this._currentLevel - 1) * 0.007)) **
+            (0.8 - (this._currentLevel - 1) * 0.007) **
                 (this._currentLevel - 1);
-        broadcastFallRate(this.currentFallRate);
+        broadcastFallRate(this._currentFallRate);
     }
 
     /**
      * Increase the fall rate to be the next-level's equivalent.
      */
     private increaseFallRate() {
-        this.currentFallRate =
-            1000 * (0.8 * (this._currentLevel * 0.007)) ** this._currentLevel;
-        broadcastFallRate(this.currentFallRate);
+        this._currentFallRate =
+            1000 * (0.8 - this._currentLevel * 0.007) ** this._currentLevel;
+        broadcastFallRate(this._currentFallRate);
     }
 
     /**
      * Decrease the fall rate to be the previous level's equivalent.
      */
     private decreaseFallRate() {
-        this.currentFallRate =
+        this._currentFallRate =
             1000 *
-            (0.8 * ((this._currentLevel - 2) * 0.007)) **
+            (0.8 - (this._currentLevel - 2) * 0.007) **
                 (this._currentLevel - 2);
-        broadcastFallRate(this.currentFallRate);
+        broadcastFallRate(this._currentFallRate);
     }
 
     /**
      * Reset the values of the fallrate & level. Used upon restarting the game.
      */
     public resetLevel() {
-        this.currentFallRate = 1000;
+        this._currentFallRate = 1000;
         this._currentLevel = 1;
     }
 
@@ -105,6 +109,6 @@ export class Level {
      * @param socket The client requesting data.
      */
     public getFallRate(socket: SocketLevel) {
-        socket.emit("updateFallRate", this.currentFallRate);
+        socket.emit("updateFallRate", this._currentFallRate);
     }
 }

--- a/server/src/Level.ts
+++ b/server/src/Level.ts
@@ -1,16 +1,18 @@
 import { ToServerEvents, ToClientEvents } from "common/messages/sceneGameArena";
-import { broadcastFallRate } from "../index";
 import { Socket } from "socket.io";
+import { broadcast } from "./broadcast";
 
 type SocketLevel = Socket<ToServerEvents, ToClientEvents>;
 
 export class Level {
     private _currentLevel: number;
     private _currentFallRate: number;
+    private broadcastFallRate: broadcast["fallRate"];
 
-    constructor() {
+    constructor(fallRateEvent: broadcast["fallRate"]) {
         this._currentLevel = 1;
         this._currentFallRate = 1000;
+        this.broadcastFallRate = fallRateEvent;
     }
 
     get currentLevel(): number {
@@ -73,7 +75,7 @@ export class Level {
             1000 *
             (0.8 - (this._currentLevel - 1) * 0.007) **
                 (this._currentLevel - 1);
-        broadcastFallRate(this._currentFallRate);
+        this.broadcastFallRate(this._currentFallRate);
     }
 
     /**
@@ -82,7 +84,7 @@ export class Level {
     private increaseFallRate() {
         this._currentFallRate =
             1000 * (0.8 - this._currentLevel * 0.007) ** this._currentLevel;
-        broadcastFallRate(this._currentFallRate);
+        this.broadcastFallRate(this._currentFallRate);
     }
 
     /**
@@ -93,7 +95,7 @@ export class Level {
             1000 *
             (0.8 - (this._currentLevel - 2) * 0.007) **
                 (this._currentLevel - 2);
-        broadcastFallRate(this._currentFallRate);
+        this.broadcastFallRate(this._currentFallRate);
     }
 
     /**

--- a/server/src/PlayerQueue.ts
+++ b/server/src/PlayerQueue.ts
@@ -62,6 +62,7 @@ export class PlayerQueue {
      * @param socket The socket to be removed from the queue.
      */
     public removeFromQueue(socket: SocketQueue) {
+        /* eslint-disable @typescript-eslint/no-unused-vars */
         this.queue = this.queue.filter(function (value, index, arr) {
             return value != socket;
         });

--- a/server/src/Scoreboard.ts
+++ b/server/src/Scoreboard.ts
@@ -1,10 +1,6 @@
 import { PlayerColor } from "./PlayerAttributes";
 import { Level } from "./Level";
-import {
-    broadcastUpdateScoreboard,
-    broadcastToSceneWaitingRoom,
-    broadcastToSceneGameOver,
-} from "../index";
+import { broadcast } from "./broadcast";
 
 import { ToServerEvents, ToClientEvents } from "common/messages/scoreboard";
 import { ColoredScore } from "common/shared";
@@ -20,13 +16,24 @@ export class Scoreboard {
     private _accumulatedScore: number;
     private _scoreMap: Array<ColoredScore>;
     private _finalScores: Array<ColoredScore>;
+    private broadcastToSceneGameOver: broadcast["toSceneGameOver"];
+    private broadcastToSceneWaitingRoom: broadcast["toSceneWaitingRoom"];
+    private broadcastUpdateScoreboard: broadcast["updateScoreboard"];
 
-    constructor() {
+    constructor(
+        gameOverEvent: broadcast["toSceneGameOver"],
+        waitingRoomEvent: broadcast["toSceneWaitingRoom"],
+        updateScoreboardEvent: broadcast["updateScoreboard"]
+    ) {
         this._orangeScore = 0;
         this._greenScore = 0;
         this._pinkScore = 0;
         this._blueScore = 0;
         this._accumulatedScore = 0;
+
+        this.broadcastToSceneGameOver = gameOverEvent;
+        this.broadcastToSceneWaitingRoom = waitingRoomEvent;
+        this.broadcastUpdateScoreboard = updateScoreboardEvent;
 
         this._finalScores = [];
 
@@ -228,7 +235,7 @@ export class Scoreboard {
         });
 
         // Notify all connected users.
-        broadcastUpdateScoreboard(clonedData);
+        this.broadcastUpdateScoreboard(clonedData);
     }
 
     /**
@@ -245,11 +252,11 @@ export class Scoreboard {
         });
 
         // Show scoreboard to all connected users.
-        broadcastToSceneGameOver(this._finalScores);
+        this.broadcastToSceneGameOver(this._finalScores);
 
         // Return to starting sequence after 30 seconds.
         setTimeout(() => {
-            broadcastToSceneWaitingRoom();
+            this.broadcastToSceneWaitingRoom();
             this.resetScores();
         }, 30000);
     }

--- a/server/src/Scoreboard.ts
+++ b/server/src/Scoreboard.ts
@@ -16,23 +16,15 @@ export class Scoreboard {
     private _accumulatedScore: number;
     private _scoreMap: Array<ColoredScore>;
     private _finalScores: Array<ColoredScore>;
-    private broadcastToSceneGameOver: broadcast["toSceneGameOver"];
-    private broadcastToSceneWaitingRoom: broadcast["toSceneWaitingRoom"];
     private broadcastUpdateScoreboard: broadcast["updateScoreboard"];
 
-    constructor(
-        gameOverEvent: broadcast["toSceneGameOver"],
-        waitingRoomEvent: broadcast["toSceneWaitingRoom"],
-        updateScoreboardEvent: broadcast["updateScoreboard"]
-    ) {
+    constructor(updateScoreboardEvent: broadcast["updateScoreboard"]) {
         this._orangeScore = 0;
         this._greenScore = 0;
         this._pinkScore = 0;
         this._blueScore = 0;
         this._accumulatedScore = 0;
 
-        this.broadcastToSceneGameOver = gameOverEvent;
-        this.broadcastToSceneWaitingRoom = waitingRoomEvent;
         this.broadcastUpdateScoreboard = updateScoreboardEvent;
 
         this._finalScores = [];
@@ -109,6 +101,10 @@ export class Scoreboard {
         return this._finalScores;
     }
 
+    get accumulatedScore(): number {
+        return this._accumulatedScore;
+    }
+
     /**
      * Reset all scores.
      */
@@ -118,6 +114,7 @@ export class Scoreboard {
         this._pinkScore = 0;
         this._blueScore = 0;
         this._accumulatedScore = 0;
+        this._finalScores = [];
     }
 
     /**
@@ -239,9 +236,10 @@ export class Scoreboard {
     }
 
     /**
-     * Display the game over screen with the fullscreen scoreboard UI.
+     * Get the final player scores.
+     * @returns The final scores of the players.
      */
-    public displaySceneGameOver() {
+    public getFinalScores() {
         this.updateScoreMap();
 
         this._finalScores = Object.assign([], this._scoreMap);
@@ -251,13 +249,6 @@ export class Scoreboard {
             points: this.currentTeamScore,
         });
 
-        // Show scoreboard to all connected users.
-        this.broadcastToSceneGameOver(this._finalScores);
-
-        // Return to starting sequence after 30 seconds.
-        setTimeout(() => {
-            this.broadcastToSceneWaitingRoom();
-            this.resetScores();
-        }, 30000);
+        return this._finalScores;
     }
 }

--- a/server/src/Spectator.ts
+++ b/server/src/Spectator.ts
@@ -1,8 +1,5 @@
 import { Level } from "./Level";
-import {
-    broadcastHideVotingSequence,
-    broadcastShowVotingSequence,
-} from "../index";
+import { broadcast } from "./broadcast";
 
 import { ToServerEvents, ToClientEvents } from "common/messages/spectator";
 import { Socket } from "socket.io";
@@ -22,8 +19,13 @@ export class Spectator {
     };
     private _countdownValue: number;
     private _secondVotingRoundSelection: string;
+    private broadcastShowVotingSequence: broadcast["showVotingSequence"];
+    private broadcastHideVotingSequence: broadcast["hideVotingSequence"];
 
-    constructor() {
+    constructor(
+        showVotingSequenceEvent: broadcast["showVotingSequence"],
+        hideVotingSequenceEvent: broadcast["hideVotingSequence"]
+    ) {
         this._isFirstRoundVoting = true;
         this._isAcceptingVotes = false;
         this._isVoteRunning = false;
@@ -36,6 +38,8 @@ export class Spectator {
         };
         this._countdownValue = 10;
         this._secondVotingRoundSelection = "null";
+        this.broadcastShowVotingSequence = showVotingSequenceEvent;
+        this.broadcastHideVotingSequence = hideVotingSequenceEvent;
     }
 
     get countdownValue(): number {
@@ -100,7 +104,7 @@ export class Spectator {
         this._secondVotingRoundSelection = "null";
         this.resetVotingRound();
 
-        broadcastShowVotingSequence("initialDisplay");
+        this.broadcastShowVotingSequence("initialDisplay");
         this.startCountdown();
 
         setTimeout(() => {
@@ -133,7 +137,7 @@ export class Spectator {
         this._secondVotingRoundSelection = votingSet;
         this.resetVotingRound();
 
-        broadcastShowVotingSequence(votingSet);
+        this.broadcastShowVotingSequence(votingSet);
         this.startCountdown();
 
         setTimeout(() => {
@@ -174,7 +178,7 @@ export class Spectator {
     public makeDecision(level: Level) {
         // FIXME: Ensure the game is still running before continuing.
 
-        broadcastHideVotingSequence();
+        this.broadcastHideVotingSequence();
         this._isAcceptingVotes = false;
         this._isVoteRunning = false;
 

--- a/server/src/Spectator.ts
+++ b/server/src/Spectator.ts
@@ -109,7 +109,7 @@ export class Spectator {
 
         setTimeout(() => {
             this.makeDecision(level);
-        }, 12000);
+        }, 10000);
     }
 
     /**
@@ -142,7 +142,7 @@ export class Spectator {
 
         setTimeout(() => {
             this.makeDecision(level);
-        }, 12000);
+        }, 10000);
     }
 
     /**

--- a/server/src/broadcast.ts
+++ b/server/src/broadcast.ts
@@ -1,0 +1,12 @@
+import { ColoredScore } from "common/shared";
+
+export interface broadcast {
+    updateScoreboard(msg: Array<ColoredScore>): void;
+    toSceneWaitingRoom(): void;
+    toSceneGameArena(): void;
+    toSceneGameOver(msg: Array<ColoredScore>): void;
+    showVotingSequence(votingSequence: string): void;
+    hideVotingSequence(): void;
+    remainingPlayers(playersNeeded: number): void;
+    fallRate(fallRate: number): void;
+}

--- a/server/src/tests/Scoreboard.test.ts
+++ b/server/src/tests/Scoreboard.test.ts
@@ -1,0 +1,61 @@
+import { Scoreboard } from "../Scoreboard";
+import { Level } from "../Level";
+
+describe("Testing 'Spectator'", () => {
+    let board: Scoreboard;
+    const level: Level = new Level(jest.fn());
+
+    jest.useFakeTimers();
+    jest.spyOn(global, "setTimeout");
+
+    beforeEach(() => {
+        board = new Scoreboard(jest.fn());
+    });
+
+    test("Test Increment User Scores", () => {
+        const updateScoreboardUI = jest.spyOn(board, "updateScoreboardUI");
+
+        expect(board.currentTeamScore).toBe(0);
+        board.incrementScore(0, 10, level);
+
+        expect(board.orangeScore).toBe(10);
+        expect(board.currentTeamScore).toBe(10);
+        expect(updateScoreboardUI).toHaveBeenCalled();
+    });
+
+    test("Test Resetting AccumulatedScore Upon Level Increment", () => {
+        const updateLevel = jest.spyOn(level, "checkUpdateLevel");
+
+        expect(board.accumulatedScore).toBe(0);
+        board.incrementScore(0, 10, level);
+        expect(board.accumulatedScore).toBe(10);
+
+        board.incrementScore(1, 10, level);
+        expect(updateLevel).toHaveBeenCalled();
+        expect(board.accumulatedScore).toBe(0);
+    });
+
+    test("Test Decrement User Scores", () => {
+        const updateScoreboardUI = jest.spyOn(board, "updateScoreboardUI");
+
+        expect(board.orangeScore).toBe(0);
+        board.decrementScore(0, 10, level.currentLevel);
+        expect(board.orangeScore).toBe(0);
+
+        board.incrementScore(0, 10, level);
+        expect(board.orangeScore).toBe(10);
+
+        board.decrementScore(0, 10, level.currentLevel);
+        expect(board.orangeScore).toBe(0);
+        expect(updateScoreboardUI).toHaveBeenCalled();
+    });
+
+    test("Test Get Final Scores", () => {
+        expect(board.finalScores.length).toBe(0);
+        expect(board.getFinalScores().length).toBe(5);
+
+        // Increment the score and ensure its properly copied into the final scores.
+        board.incrementScore(0, 10, level);
+        expect(board.getFinalScores()[0].points).toBe(10);
+    });
+});

--- a/server/src/tests/Spectator.test.ts
+++ b/server/src/tests/Spectator.test.ts
@@ -1,0 +1,79 @@
+import { Spectator } from "../Spectator";
+import { Level } from "../Level";
+
+describe("Testing 'Spectator'", () => {
+    let spectator: Spectator;
+    const level: Level = new Level(jest.fn());
+
+    jest.useFakeTimers();
+    jest.spyOn(global, "setTimeout");
+
+    beforeEach(() => {
+        spectator = new Spectator(jest.fn(), jest.fn());
+    });
+
+    test("Test if Voting State is Maintained", () => {
+        expect(spectator.isVoteRunning()).toBe("");
+        spectator.generateFirstVotingSequence(level);
+        expect(spectator.isVoteRunning()).toBe("initialDisplay");
+    });
+
+    test("Test First Voting Sequence", () => {
+        expect(spectator.countdownValue).toBe(10);
+        spectator.generateFirstVotingSequence(level);
+
+        // Run the countdown to completion. Should expect it to go from 10 -> -1.
+        jest.runAllTimers();
+        expect(spectator.countdownValue).toBe(-1);
+
+        expect(setTimeout).toHaveBeenCalled();
+        expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 10000);
+    });
+
+    test("Test Second Voting Sequence", () => {
+        expect(spectator.countdownValue).toBe(10);
+        spectator.generateSecondVotingSequence("", level);
+
+        // Run the countdown to completion. Should expect it to go from 10 -> -1.
+        jest.runAllTimers();
+        expect(spectator.countdownValue).toBe(-1);
+
+        expect(setTimeout).toHaveBeenCalled();
+        expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 10000);
+    });
+
+    test("Test Ensure Voting Sequence is Reset When Starting a Voting Sequence", () => {
+        const resetVotingRound = jest.spyOn(
+            Spectator.prototype as any,
+            "resetVotingRound"
+        );
+
+        spectator.generateFirstVotingSequence(level);
+        expect(resetVotingRound).toHaveBeenCalled();
+
+        spectator.generateSecondVotingSequence("", level);
+        expect(resetVotingRound).toHaveBeenCalled();
+    });
+
+    test("Test Voting Decision Making", () => {
+        const increaseFallRate = jest.spyOn(level, "spectatorIncreaseFallRate");
+        const secondVotingSequence = jest.spyOn(
+            spectator,
+            "generateSecondVotingSequence"
+        );
+
+        expect(spectator.isVoteRunning()).toBe("");
+        spectator.generateFirstVotingSequence(level);
+        spectator.getResult("option1");
+        spectator.makeDecision(level);
+
+        // Second voting round should commence.
+        expect(secondVotingSequence).toHaveBeenCalled();
+
+        // Simulate a vote on "option1" (increase fall rate).
+        spectator.getResult("option1");
+        spectator.makeDecision(level);
+
+        expect(increaseFallRate).toHaveBeenCalled();
+    });
+});

--- a/server/src/tests/level.test.ts
+++ b/server/src/tests/level.test.ts
@@ -1,15 +1,13 @@
 import { Level } from "../Level";
-import { broadcast } from "../broadcast";
 
 describe("Testing 'Level'", () => {
     let level: Level;
-    const fallRateEvent: broadcast["fallRate"] = jest.fn();
 
     jest.useFakeTimers();
     jest.spyOn(global, "setTimeout");
 
     beforeEach(() => {
-        level = new Level(fallRateEvent);
+        level = new Level(jest.fn());
     });
 
     test("Valid level increments", () => {

--- a/server/src/tests/level.test.ts
+++ b/server/src/tests/level.test.ts
@@ -1,0 +1,52 @@
+import { Level } from "../Level";
+
+describe("Testing 'Level'", () => {
+    let level: Level;
+
+    beforeEach(() => {
+        level = new Level();
+    });
+
+    test("Valid level increments", () => {
+        level.checkUpdateLevel(10);
+        expect(level.currentLevel).toBe(1);
+
+        level.checkUpdateLevel(20);
+        expect(level.currentLevel).toBe(2);
+    });
+
+    test("Updating Fall Rate", () => {
+        expect(level.currentFallRate).toBe(1000);
+
+        level.checkUpdateLevel(20);
+        expect(level.currentFallRate).toBe(793);
+    });
+
+    test("Spectator Increasing Fall Rate & Resetting Fall Rate after 20s", () => {
+        expect(level.currentFallRate).toBe(1000);
+
+        level.spectatorIncreaseFallRate();
+        expect(level.currentFallRate).toBe(793);
+        expect(setTimeout).toHaveBeenCalledTimes(1);
+        expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 20000);
+    });
+
+    test("Spectator Decreasing Fall Rate & Resetting Fall Rate after 20s", () => {
+        expect(level.currentFallRate).toBe(1000);
+
+        level.spectatorIncreaseFallRate();
+        expect(level.currentFallRate).toBeCloseTo(1239);
+        expect(setTimeout).toHaveBeenCalledTimes(1);
+        expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 20000);
+    });
+
+    test("Reseting Level", () => {
+        level.checkUpdateLevel(500);
+        level.checkUpdateLevel(500);
+        expect(level.currentLevel).toBe(3);
+
+        level.resetLevel();
+        expect(level.currentLevel).toBe(1);
+        expect(level.currentFallRate).toBe(1000);
+    });
+});

--- a/server/src/tests/level.test.ts
+++ b/server/src/tests/level.test.ts
@@ -1,10 +1,15 @@
 import { Level } from "../Level";
+import { broadcast } from "../broadcast";
 
 describe("Testing 'Level'", () => {
     let level: Level;
+    const fallRateEvent: broadcast["fallRate"] = jest.fn();
+
+    jest.useFakeTimers();
+    jest.spyOn(global, "setTimeout");
 
     beforeEach(() => {
-        level = new Level();
+        level = new Level(fallRateEvent);
     });
 
     test("Valid level increments", () => {
@@ -27,16 +32,16 @@ describe("Testing 'Level'", () => {
 
         level.spectatorIncreaseFallRate();
         expect(level.currentFallRate).toBe(793);
-        expect(setTimeout).toHaveBeenCalledTimes(1);
+        expect(setTimeout).toHaveBeenCalled();
         expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 20000);
     });
 
     test("Spectator Decreasing Fall Rate & Resetting Fall Rate after 20s", () => {
         expect(level.currentFallRate).toBe(1000);
 
-        level.spectatorIncreaseFallRate();
-        expect(level.currentFallRate).toBeCloseTo(1239);
-        expect(setTimeout).toHaveBeenCalledTimes(1);
+        level.spectatorDecreaseFallRate();
+        expect(level.currentFallRate).toBeCloseTo(1239, 0);
+        expect(setTimeout).toHaveBeenCalled();
         expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 20000);
     });
 


### PR DESCRIPTION
# Test Suite
All server classes except for the `PlayerQueue.ts` and `SceneTracker.ts` files have tests defined for them.
`SceneTracker.ts` is literally a setter/getter class so I don't believe that needs a test suite defined for it.
`PlayerQueue.ts` depends on sockets. I've been trying to mock a socket object so I can pass it in, but no luck just yet.

# Event Broadcasting
## Old Method
Broadcast events used to be defined as functions originating from `index.ts` (server-side). This caused issues when writing tests for the server files because of circular dependencies.
For example, when writing test cases for `Level.ts`, this file would depend on the broadcast events from `index.ts` (which also instantiated its own Level() class). This would error out when performing tests.
## New Method
Server files will import from the interface `broadcast.ts` (contains all broadcast function definitions) if they need to broadcast information to all clients. The functions are defined in `index.ts` and passed into the classes that require their use. There is no dependency directly connecting them anymore.

# Eslint Warnings
I've added in a few ignore commands for some of the warnings that were occurring.