### PR TITLE
Spectator block sequence

### DIFF
--- a/client/src/GameState.ts
+++ b/client/src/GameState.ts
@@ -3,7 +3,6 @@ import { TetrominoType } from "common/TetrominoType";
 import { Tetromino } from "./Tetromino";
 import { BOARD_SIZE } from "common/shared";
 import { ToServerEvents, ToClientEvents } from "common/messages/game";
-import { RandomBag } from "./randomBag";
 import { TetrominoLookahead } from "./Tetromino";
 
 type GameSocket = Socket<ToClientEvents, ToServerEvents>;
@@ -21,7 +20,6 @@ export class GameState {
     // i.e. if you are player 1, these are of player 2, then 3, then 0
     otherTetrominoes: Array<Tetromino>;
     playerId!: 0 | 1 | 2 | 3;
-
 
     private newBoard() {
         const board = new Array(BOARD_SIZE);

--- a/client/src/GameState.ts
+++ b/client/src/GameState.ts
@@ -43,6 +43,7 @@ export class GameState {
         this.socket = socket;
         this.board = this.newBoard();
         this.currentTetromino = new Tetromino();
+        this.currentTetromino.initListeners(socket);
         // other player's moving piece, TODO this is synchronized with the server
         // how they are rendered is not concerned.
         this.otherTetrominoes = [

--- a/client/src/randomBag.ts
+++ b/client/src/randomBag.ts
@@ -1,36 +1,47 @@
 import { TetrominoType } from "common/TetrominoType";
 
-export class RandomBag{
+export class RandomBag {
     bagStack: Array<TetrominoType>;
 
     constructor() {
         this.bagStack = [];
-
     }
-    
+
     //using the Fisher Yates algorithm
     private shuffle() {
-    let currIdx = this.bagStack.length - 1;
+        let currIdx = this.bagStack.length - 1;
 
-    while (currIdx > 0) {
-        const randIdx = Math.floor(Math.random() * currIdx);
-        [this.bagStack[currIdx], this.bagStack[randIdx]] = [this.bagStack[randIdx], this.bagStack[currIdx]];
-        currIdx--;
+        while (currIdx > 0) {
+            const randIdx = Math.floor(Math.random() * currIdx);
+            [this.bagStack[currIdx], this.bagStack[randIdx]] = [
+                this.bagStack[randIdx],
+                this.bagStack[currIdx],
+            ];
+            currIdx--;
+        }
+        return this.bagStack;
     }
-    return this.bagStack;
-    }
-    
+
     private createBag() {
-        this.bagStack = [TetrominoType.I, TetrominoType.J, TetrominoType.L, TetrominoType.O, TetrominoType.S, TetrominoType.T, TetrominoType.Z];
+        this.bagStack = [
+            TetrominoType.I,
+            TetrominoType.J,
+            TetrominoType.L,
+            TetrominoType.O,
+            TetrominoType.S,
+            TetrominoType.T,
+            TetrominoType.Z,
+        ];
         this.shuffle();
     }
+
     public returnNextPiece() {
         if (this.bagStack.length == 0) {
             this.createBag();
         }
-        const nextPiece: TetrominoType = this.bagStack[this.bagStack.length - 1];
+        const nextPiece: TetrominoType =
+            this.bagStack[this.bagStack.length - 1];
         this.bagStack.pop();
         return nextPiece;
     }
-
 }

--- a/client/src/scene/SpectatorUI.ts
+++ b/client/src/scene/SpectatorUI.ts
@@ -16,6 +16,7 @@ export class SpectatorUI {
     private alreadyVoted: Phaser.GameObjects.Text;
     private countdownConfig: TextConfig;
     private buttonConfig: TextConfig;
+    private interval!: NodeJS.Timer;
 
     private socket: SocketSpectator;
 
@@ -109,6 +110,7 @@ export class SpectatorUI {
     private removeTimedEvent() {
         this.countdown.setText("");
         this.alreadyVoted.setText("");
+        clearInterval(this.interval);
 
         this.cookieTracker.deleteCookie("hasVoted");
 
@@ -273,9 +275,9 @@ export class SpectatorUI {
         this.updateCountdown(secondsLeft);
 
         // Start the countdown.
-        const interval = setInterval(() => {
+        this.interval = setInterval(() => {
             if (this.updateCountdown(secondsLeft)) {
-                clearInterval(interval);
+                clearInterval(this.interval);
             }
 
             secondsLeft--;

--- a/client/src/scene/SpectatorUI.ts
+++ b/client/src/scene/SpectatorUI.ts
@@ -75,10 +75,10 @@ export class SpectatorUI {
         this.socket.removeListener("hideVotingSequence");
         this.socket.removeListener("sendVotingCountdown");
 
-        this.socket.on("showVotingSequence", (votingSequence) => {
+        this.socket.on("showVotingSequence", (votingSequence, randTetros) => {
             // Only display the voting sequence for spectators.
             if (this.scene.gameState.playerId == null) {
-                this.generateTimedEvent(votingSequence);
+                this.generateTimedEvent(votingSequence, randTetros);
             }
         });
 
@@ -95,9 +95,12 @@ export class SpectatorUI {
      * Generate the spectator voting section.
      * @param valFromServer Specifies which buttons to be loading in for this sequence.
      */
-    private generateTimedEvent(valFromServer: string) {
+    private generateTimedEvent(
+        valFromServer: string,
+        randTetros: Array<string>
+    ) {
         this.removeTimedEvent();
-        this.createOptions(valFromServer);
+        this.createOptions(valFromServer, randTetros);
     }
 
     /**
@@ -116,7 +119,7 @@ export class SpectatorUI {
      * Generate options for the user to select.
      * @param votingOption This value is received from the server. Based off the value obtained, display a different set of buttons.
      */
-    private createOptions(votingOption: string) {
+    private createOptions(votingOption: string, randTetros: Array<string>) {
         this.countdown
             .setText("Vote on what happens!\n  Time left: 10")
             .setTint(0x53bb74);
@@ -168,9 +171,21 @@ export class SpectatorUI {
                 break;
             case "tetrominoSelection":
                 // Second voting step. Generate next block options.
-                this.setVotingButton(this.buttons[0], "> FIXME", "option1");
-                this.setVotingButton(this.buttons[1], "> FIXME", "option2");
-                this.setVotingButton(this.buttons[2], "> FIXME", "option3");
+                this.setVotingButton(
+                    this.buttons[0],
+                    `> Spawn ${randTetros[0]}-blocks`,
+                    "option1"
+                );
+                this.setVotingButton(
+                    this.buttons[1],
+                    `> Spawn ${randTetros[1]}-blocks`,
+                    "option2"
+                );
+                this.setVotingButton(
+                    this.buttons[2],
+                    `> Spawn ${randTetros[2]}-blocks`,
+                    "option3"
+                );
                 break;
         }
     }

--- a/common/message.ts
+++ b/common/message.ts
@@ -4,6 +4,7 @@ import * as gameMsgs from "./messages/game";
 import * as scoreboardMsgs from "./messages/scoreboard";
 import * as spectatorMsgs from "./messages/spectator";
 import * as sceneGameOverMsgs from "./messages/sceneGameOver";
+import * as tetrominoMsgs from "./messages/tetromino";
 import { TetrominoType } from "./TetrominoType";
 
 export type ServerToClientEvents = sceneWaitingRoomMsgs.ToClientEvents &
@@ -11,14 +12,16 @@ export type ServerToClientEvents = sceneWaitingRoomMsgs.ToClientEvents &
     gameMsgs.ToClientEvents &
     scoreboardMsgs.ToClientEvents &
     spectatorMsgs.ToClientEvents &
-    sceneGameOverMsgs.ToClientEvents;
+    sceneGameOverMsgs.ToClientEvents &
+    tetrominoMsgs.ToClientEvents;
 
 export type ClientToServerEvents = sceneWaitingRoomMsgs.ToServerEvents &
     sceneGameArenaMsgs.ToServerEvents &
     gameMsgs.ToClientEvents &
     scoreboardMsgs.ToServerEvents &
     spectatorMsgs.ToServerEvents &
-    sceneGameOverMsgs.ToServerEvents;
+    sceneGameOverMsgs.ToServerEvents &
+    tetrominoMsgs.ToServerEvents;
 
 export type PlayerID = 0 | 1 | 2 | 3;
 

--- a/common/messages/sceneGameArena.ts
+++ b/common/messages/sceneGameArena.ts
@@ -5,7 +5,6 @@ export interface ToClientEvents {
     updateFallRate: (fallRate: number) => void;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface ToServerEvents {
     requestFallRate: () => void;
 }

--- a/common/messages/spectator.ts
+++ b/common/messages/spectator.ts
@@ -5,6 +5,7 @@ export interface ToClientEvents {
     ) => void;
     hideVotingSequence: () => void;
     sendVotingCountdown: (secondsLeft: number) => void;
+    votedTetroToSpawn: (type: number) => void;
 }
 
 export interface ToServerEvents {

--- a/common/messages/spectator.ts
+++ b/common/messages/spectator.ts
@@ -1,5 +1,8 @@
 export interface ToClientEvents {
-    showVotingSequence: (votingSequence: string) => void;
+    showVotingSequence: (
+        votingSequence: string,
+        randTetros: Array<string>
+    ) => void;
     hideVotingSequence: () => void;
     sendVotingCountdown: (secondsLeft: number) => void;
 }

--- a/common/messages/tetromino.ts
+++ b/common/messages/tetromino.ts
@@ -1,0 +1,6 @@
+export interface ToClientEvents {
+    votedTetroToSpawn: (type: number) => void;
+}
+
+/* eslint-disable-next-line @typescript-eslint/no-empty-interface */
+export interface ToServerEvents {}

--- a/server/index.ts
+++ b/server/index.ts
@@ -87,7 +87,7 @@ export function broadcastToSceneGameOver(msg: Array<ColoredScore>) {
 }
 
 export function broadcastShowVotingSequence(votingSequence: string) {
-    io.sockets.emit("showVotingSequence", votingSequence);
+    io.sockets.emit("showVotingSequence", votingSequence, spectator.randTetros);
 }
 
 export function broadcastHideVotingSequence() {

--- a/server/index.ts
+++ b/server/index.ts
@@ -88,6 +88,10 @@ const remainingPlayers: broadcast["remainingPlayers"] = (
 const fallRate: broadcast["fallRate"] = (fallRate: number) => {
     io.sockets.emit("updateFallRate", fallRate);
 };
+
+const votedTetroToSpawn: broadcast["votedTetroToSpawn"] = (type: number) => {
+    io.sockets.emit("votedTetroToSpawn", type);
+};
 // ==============================================
 
 console.log(`Server started at port ${port}`);
@@ -95,7 +99,11 @@ let playerCounter: 0 | 1 | 2 | 3 = 0; // FIXME: Remove this on final version.
 const scoreboard = new Scoreboard(updateScoreboard);
 const level = new Level(fallRate);
 const queue = new PlayerQueue(remainingPlayers, toSceneGameArena);
-const spectator = new Spectator(showVotingSequence, hideVotingSequence);
+const spectator = new Spectator(
+    showVotingSequence,
+    hideVotingSequence,
+    votedTetroToSpawn
+);
 const scene = new SceneTracker();
 
 /**

--- a/server/src/Spectator.ts
+++ b/server/src/Spectator.ts
@@ -214,6 +214,10 @@ export class Spectator {
             this._previouslyVotedOption = allOptions[selectedIndex];
         }
 
+        const tetrominoTypes = Object.keys(TetrominoType).filter((item) => {
+            return isNaN(Number(item));
+        });
+
         // The option "noAction" will perform no actions. As such, it is excluded from the following switch statement.
         switch (allOptions[selectedIndex]) {
             case "option1":
@@ -222,13 +226,14 @@ export class Spectator {
                 } else if (this._previouslyVotedOption == "option1") {
                     level.spectatorIncreaseFallRate();
                 } else if (this._previouslyVotedOption == "option2") {
-                    // let type = Object.keys(Object.keys(TetrominoType).indexOf(this._randTetros[0]));
+                    // BROADCAST HERE.
+                    const type = tetrominoTypes.indexOf(this._randTetros[0]);
                     console.log("Spawning in tetromino"); // FIXME: Need to spawn in a tetromino for the players for 20 seconds.
                 }
                 break;
             case "option2":
                 if (this._isFirstRoundVoting) {
-                    this.generateRandTetros(TetrominoType);
+                    this.generateRandTetros(tetrominoTypes);
                     this.generateSecondVotingSequence(
                         "tetrominoSelection",
                         level
@@ -249,11 +254,7 @@ export class Spectator {
         }
     }
 
-    private generateRandTetros(tetroTypes: typeof TetrominoType) {
-        let enumValues = Object.keys(tetroTypes).filter((item) => {
-            return isNaN(Number(item));
-        });
-
+    private generateRandTetros(enumValues: Array<string>) {
         this._randTetros = [];
 
         while (this._randTetros.length != 3) {

--- a/server/src/Spectator.ts
+++ b/server/src/Spectator.ts
@@ -22,10 +22,12 @@ export class Spectator {
     private _randTetros: Array<string>;
     private broadcastShowVotingSequence: broadcast["showVotingSequence"];
     private broadcastHideVotingSequence: broadcast["hideVotingSequence"];
+    private broadcastVotedTetroToSpawn: broadcast["votedTetroToSpawn"];
 
     constructor(
         showVotingSequenceEvent: broadcast["showVotingSequence"],
-        hideVotingSequenceEvent: broadcast["hideVotingSequence"]
+        hideVotingSequenceEvent: broadcast["hideVotingSequence"],
+        votedTetroToSpawn: broadcast["votedTetroToSpawn"]
     ) {
         this._isFirstRoundVoting = true;
         this._isAcceptingVotes = false;
@@ -42,6 +44,7 @@ export class Spectator {
         this._secondVotingRoundSelection = "null";
         this.broadcastShowVotingSequence = showVotingSequenceEvent;
         this.broadcastHideVotingSequence = hideVotingSequenceEvent;
+        this.broadcastVotedTetroToSpawn = votedTetroToSpawn;
     }
 
     get countdownValue(): number {
@@ -119,7 +122,7 @@ export class Spectator {
 
         setTimeout(() => {
             this.makeDecision(level);
-        }, 10000);
+        }, 12000);
     }
 
     /**
@@ -152,7 +155,7 @@ export class Spectator {
 
         setTimeout(() => {
             this.makeDecision(level);
-        }, 10000);
+        }, 12000);
     }
 
     /**
@@ -229,9 +232,10 @@ export class Spectator {
                 } else if (this._previouslyVotedOption == "option1") {
                     level.spectatorIncreaseFallRate();
                 } else if (this._previouslyVotedOption == "option2") {
-                    // BROADCAST HERE.
-                    const type = tetrominoTypes.indexOf(this._randTetros[0]);
-                    console.log("Spawning in tetromino"); // FIXME: Need to spawn in a tetromino for the players for 20 seconds.
+                    this.broadcastVotedTetroToSpawn(
+                        tetrominoTypes.indexOf(this._randTetros[0])
+                    );
+                    console.log("Spawning in tetromino 1"); // FIXME: Need to spawn in a tetromino for the players for 20 seconds.
                 }
                 break;
             case "option2":
@@ -244,6 +248,9 @@ export class Spectator {
                 } else if (this._previouslyVotedOption == "option1") {
                     level.spectatorDecreaseFallRate();
                 } else if (this._previouslyVotedOption == "option2") {
+                    this.broadcastVotedTetroToSpawn(
+                        tetrominoTypes.indexOf(this._randTetros[1])
+                    );
                     console.log("Spawning in tetromino option 2 ..."); // FIXME: Spawn in tetrominos for players for 20 seconds.
                 }
                 break;
@@ -251,12 +258,19 @@ export class Spectator {
                 if (this._isFirstRoundVoting) {
                     console.log("Randomizing player blocks"); // FIXME: Randomize player blocks.
                 } else if (this._previouslyVotedOption == "option2") {
+                    this.broadcastVotedTetroToSpawn(
+                        tetrominoTypes.indexOf(this._randTetros[2])
+                    );
                     console.log("Spawning in tetromino option 3..."); // FIXME: Spawn in tetrominos for players for 20 seconds.
                 }
                 break;
         }
     }
 
+    /**
+     * Select 3 random tetrominoes from the list of all tetrominoes.
+     * @param enumValues The list of keys from the TetrominoType enum.
+     */
     private generateRandTetros(enumValues: Array<string>) {
         this._randTetros = [];
 

--- a/server/src/broadcast.ts
+++ b/server/src/broadcast.ts
@@ -9,4 +9,5 @@ export interface broadcast {
     hideVotingSequence(): void;
     remainingPlayers(playersNeeded: number): void;
     fallRate(fallRate: number): void;
+    votedTetroToSpawn(type: number): void;
 }

--- a/server/src/tests/Spectator.test.ts
+++ b/server/src/tests/Spectator.test.ts
@@ -9,7 +9,7 @@ describe("Testing 'Spectator'", () => {
     jest.spyOn(global, "setTimeout");
 
     beforeEach(() => {
-        spectator = new Spectator(jest.fn(), jest.fn());
+        spectator = new Spectator(jest.fn(), jest.fn(), jest.fn());
     });
 
     test("Test if Voting State is Maintained", () => {
@@ -27,7 +27,10 @@ describe("Testing 'Spectator'", () => {
         expect(spectator.countdownValue).toBe(-1);
 
         expect(setTimeout).toHaveBeenCalled();
-        expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 10000);
+
+        // From the client's perspective, they still get a voting option for 10 seconds.
+        // The server makes a decision in 12 seconds to give a small buffer between voting rounds.
+        expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 12000);
     });
 
     test("Test Second Voting Sequence", () => {
@@ -39,7 +42,10 @@ describe("Testing 'Spectator'", () => {
         expect(spectator.countdownValue).toBe(-1);
 
         expect(setTimeout).toHaveBeenCalled();
-        expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 10000);
+
+        // From the client's perspective, they still get a voting option for 10 seconds.
+        // The server makes a decision in 12 seconds to give a small buffer between voting rounds.
+        expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 12000);
     });
 
     test("Test Ensure Voting Sequence is Reset When Starting a Voting Sequence", () => {


### PR DESCRIPTION
When spectators vote to select the next block to fall, the server will randomly select 3 tetromino types and allow spectators to vote on them.
A new event `votedTetroToSpawn` is broadcast out to all users.
When a player receives this event, for the next 20 seconds, all tetrominoes that respawn will be of that specified type.

I've also reverted the delay between generating a voting sequence and making a decision to 12 seconds (it just feels better since it gives that small buffer between voting sequences).