### PR TITLE
Fix I-type tetromino not being rendered.

### DIFF
--- a/client/src/scene/SceneGameArena.ts
+++ b/client/src/scene/SceneGameArena.ts
@@ -183,7 +183,7 @@ export class SceneGameArena extends Phaser.Scene {
         for (let row = 0; row < BOARD_SIZE; row++) {
             for (let col = 0; col < BOARD_SIZE; col++) {
                 this.renderedBoard[row][col]?.destroy();
-                if (this.gameState.board[row][col]) {
+                if (this.gameState.board[row][col] !== null) {
                     const x = (col + 0.5) * TILE_SIZE;
                     const y = (row + 0.5) * TILE_SIZE;
                     this.renderedBoard[row][col] = this.add.rectangle(


### PR DESCRIPTION
This is a cause of rendering function checking board with naive boolean check + `TetrominoType.I` is compiled to `0` which fails the naive boolean check.

---
This should no longer be an issue with `sprites` branch merged