### PR TITLE
Disable movement if in opposite section

### DIFF
--- a/client/src/GameState.ts
+++ b/client/src/GameState.ts
@@ -142,6 +142,9 @@ export class GameState {
         });
     }
 
+    /**
+     * @returns True if the current Tetromino is in the opposite players section.
+     */
     public isInOppositeSection() {
         return this.currentTetromino.position[0] >= 25;
     }

--- a/client/src/GameState.ts
+++ b/client/src/GameState.ts
@@ -143,7 +143,7 @@ export class GameState {
     }
 
     public isInOppositeSection() {
-        return this.currentTetromino.position[0] > 25;
+        return this.currentTetromino.position[0] >= 25;
     }
 
     /**

--- a/client/src/GameState.ts
+++ b/client/src/GameState.ts
@@ -22,7 +22,6 @@ export class GameState {
     otherTetrominoes: Array<Tetromino>;
     playerId!: 0 | 1 | 2 | 3;
 
-
     private newBoard() {
         const board = new Array(BOARD_SIZE);
         for (let r = 0; r < BOARD_SIZE; r++) {
@@ -141,6 +140,10 @@ export class GameState {
         return lookahead.tiles.some(([row, col]) => {
             return this.board[row][col] != null;
         });
+    }
+
+    public isInOppositeSection() {
+        return this.currentTetromino.position[0] > 25;
     }
 
     /**

--- a/client/src/scene/SceneGameArena.ts
+++ b/client/src/scene/SceneGameArena.ts
@@ -155,19 +155,35 @@ export class SceneGameArena extends Phaser.Scene {
 
     private updateUserInput() {
         let moved = false;
-        if (this.keys.a.isDown || this.keys.left.isDown) {
+        if (
+            (this.keys.a.isDown || this.keys.left.isDown) &&
+            this.gameState.playerId !== null &&
+            !this.gameState.isInOppositeSection()
+        ) {
             moved = this.gameState.moveIfCan(
                 Tetromino.slide(-1) // left
             );
-        } else if (this.keys.d.isDown || this.keys.right.isDown) {
+        } else if (
+            (this.keys.d.isDown || this.keys.right.isDown) &&
+            this.gameState.playerId !== null &&
+            !this.gameState.isInOppositeSection()
+        ) {
             moved = this.gameState.moveIfCan(
                 Tetromino.slide(1) // right
             );
-        } else if (this.keys.q.isDown || this.keys.z.isDown) {
+        } else if (
+            (this.keys.q.isDown || this.keys.z.isDown) &&
+            this.gameState.playerId !== null &&
+            !this.gameState.isInOppositeSection()
+        ) {
             moved = this.gameState.moveIfCan(
                 Tetromino.rotateCCW // counter clock wise
             );
-        } else if (this.keys.e.isDown || this.keys.x.isDown) {
+        } else if (
+            (this.keys.e.isDown || this.keys.x.isDown) &&
+            this.gameState.playerId !== null &&
+            !this.gameState.isInOppositeSection()
+        ) {
             moved = this.gameState.moveIfCan(
                 Tetromino.rotateCW // clock wise
             );


### PR DESCRIPTION
Added in checks to determine if the current Tetromino is entering the opposite player's section. If so, then movement is disabled.

I've also added in some more checks to ensure spectators cannot move tetrominoes.