### PR TITLE
Voted tetromino to spawn

### DIFF
--- a/client/src/scene/SceneGameArena.ts
+++ b/client/src/scene/SceneGameArena.ts
@@ -130,7 +130,7 @@ export class SceneGameArena extends Phaser.Scene {
         let moved = false;
         if (
             (this.keys.a.isDown || this.keys.left.isDown) &&
-            this.gameState.playerId !== null &&
+            this.gameState.playerId != null &&
             !this.gameState.isInOppositeSection()
         ) {
             moved = this.gameState.moveIfCan(
@@ -138,7 +138,7 @@ export class SceneGameArena extends Phaser.Scene {
             );
         } else if (
             (this.keys.d.isDown || this.keys.right.isDown) &&
-            this.gameState.playerId !== null &&
+            this.gameState.playerId != null &&
             !this.gameState.isInOppositeSection()
         ) {
             moved = this.gameState.moveIfCan(
@@ -146,7 +146,7 @@ export class SceneGameArena extends Phaser.Scene {
             );
         } else if (
             (this.keys.q.isDown || this.keys.z.isDown) &&
-            this.gameState.playerId !== null &&
+            this.gameState.playerId != null &&
             !this.gameState.isInOppositeSection()
         ) {
             moved = this.gameState.moveIfCan(
@@ -154,7 +154,7 @@ export class SceneGameArena extends Phaser.Scene {
             );
         } else if (
             (this.keys.e.isDown || this.keys.x.isDown) &&
-            this.gameState.playerId !== null &&
+            this.gameState.playerId != null &&
             !this.gameState.isInOppositeSection()
         ) {
             moved = this.gameState.moveIfCan(

--- a/client/src/scene/SpectatorUI.ts
+++ b/client/src/scene/SpectatorUI.ts
@@ -5,6 +5,7 @@ import { BOARD_PX, TILE_SIZE, COLORS } from "common/shared";
 import { ToServerEvents, ToClientEvents } from "common/messages/spectator";
 
 import { CookieTracker } from "../CookieTracker";
+import { TetrominoType } from "common/TetrominoType";
 
 type SocketSpectator = Socket<ToClientEvents, ToServerEvents>;
 
@@ -25,9 +26,9 @@ export class SpectatorUI {
             ["decrease fall rate", "option2"],
         ],
         tetrominoSelection: [
-            ["fixme piece", "option1"],
-            ["fixme", "option2"],
-            ["fixme", "option3"],
+            ["placeholder", "option1"],
+            ["placeholder", "option2"],
+            ["placeholder", "option3"],
         ],
     };
 
@@ -67,7 +68,7 @@ export class SpectatorUI {
         this.buttons = new Array(4);
         for (let i = 0; i < this.buttons.length; i++) {
             this.buttons[i] = scene.add
-                .bitmapText(startX, startY + i * 35, "brawl", longestOption)
+                .bitmapText(startX, startY + i * 45, "brawl", longestOption)
                 .setVisible(false)
                 .setInteractive({ useHandCursor: true })
                 .on("pointerover", () => {
@@ -102,8 +103,8 @@ export class SpectatorUI {
         this.socket.removeListener("hideVotingSequence");
         this.socket.removeListener("sendVotingCountdown");
 
-        this.socket.on("showVotingSequence", (votingSequence) => {
-            this.generateTimedEvent(votingSequence);
+        this.socket.on("showVotingSequence", (votingSequence, randTetros) => {
+            this.generateTimedEvent(votingSequence, randTetros);
         });
 
         this.socket.on("hideVotingSequence", () => {
@@ -120,9 +121,12 @@ export class SpectatorUI {
      * Generate the spectator voting section.
      * @param valFromServer Specifies which buttons to be loading in for this sequence.
      */
-    private generateTimedEvent(valFromServer: string) {
+    private generateTimedEvent(
+        valFromServer: string,
+        randTetros: Array<number>
+    ) {
         this.removeTimedEvent();
-        this.createOptions(valFromServer);
+        this.createOptions(valFromServer, randTetros);
     }
 
     /**
@@ -142,7 +146,7 @@ export class SpectatorUI {
      * Generate options for the user to select.
      * @param votingOption This value is received from the server. Based off the value obtained, display a different set of buttons.
      */
-    private createOptions(votingOption: string) {
+    private createOptions(votingOption: string, randTetros: Array<number>) {
         this.header.setVisible(true);
         this.countdown.setTint(COLORS.green).setVisible(true);
         this.updateCountdown(10);
@@ -165,6 +169,20 @@ export class SpectatorUI {
                     this.alreadyVoted.setVisible(true);
                 });
         });
+
+        // FIXME: Improperly displaying data on screen.
+        console.log(`> Spawn ${TetrominoType[randTetros[0]]} pieces`);
+        if (votingOption == "tetrominoSelection") {
+            this.buttons[0].setText(
+                `> Spawn ${TetrominoType[randTetros[0]]} pieces`
+            );
+            this.buttons[1].setText(
+                `> Spawn ${TetrominoType[randTetros[1]]} pieces`
+            );
+            this.buttons[2].setText(
+                `> Spawn ${TetrominoType[randTetros[2]]} pieces`
+            );
+        }
     }
 
     /**

--- a/common/messages/game.ts
+++ b/common/messages/game.ts
@@ -4,6 +4,7 @@ export interface ToClientEvents {
     initPlayer: (playerId: 0 | 1 | 2 | 3) => void;
     playerMove: (playerId: PlayerID, tetrominoState: TetrominoState) => void;
     playerPlace: (playerId: PlayerID, tetrominoState: TetrominoState) => void;
+    votedTetroToSpawn: (type: number) => void;
 }
 
 export interface ToServerEvents {

--- a/common/messages/sceneGameArena.ts
+++ b/common/messages/sceneGameArena.ts
@@ -5,7 +5,6 @@ export interface ToClientEvents {
     updateFallRate: (fallRate: number) => void;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface ToServerEvents {
     requestFallRate: () => void;
 }

--- a/common/messages/spectator.ts
+++ b/common/messages/spectator.ts
@@ -1,5 +1,8 @@
 export interface ToClientEvents {
-    showVotingSequence: (votingSequence: string) => void;
+    showVotingSequence: (
+        votingSequence: string,
+        randTetros: Array<number>
+    ) => void;
     hideVotingSequence: () => void;
     sendVotingCountdown: (secondsLeft: number) => void;
 }

--- a/common/messages/spectator.ts
+++ b/common/messages/spectator.ts
@@ -5,6 +5,7 @@ export interface ToClientEvents {
     ) => void;
     hideVotingSequence: () => void;
     sendVotingCountdown: (secondsLeft: number) => void;
+    votedTetroToSpawn: (type: number) => void;
 }
 
 export interface ToServerEvents {

--- a/server/index.ts
+++ b/server/index.ts
@@ -91,6 +91,10 @@ const remainingPlayers: broadcast["remainingPlayers"] = (
 const fallRate: broadcast["fallRate"] = (fallRate: number) => {
     io.sockets.emit("updateFallRate", fallRate);
 };
+
+const votedTetroToSpawn: broadcast["votedTetroToSpawn"] = (type: number) => {
+    io.sockets.emit("votedTetroToSpawn", type);
+};
 // ==============================================
 
 console.log(`Server started at port ${port}`);
@@ -98,7 +102,11 @@ let playerCounter: 0 | 1 | 2 | 3 = 0; // FIXME: Remove this on final version.
 const scoreboard = new Scoreboard(updateScoreboard);
 const level = new Level(fallRate);
 const queue = new PlayerQueue(remainingPlayers, toSceneGameArena);
-const spectator = new Spectator(showVotingSequence, hideVotingSequence);
+const spectator = new Spectator(
+    showVotingSequence,
+    hideVotingSequence,
+    votedTetroToSpawn
+);
 const scene = new SceneTracker();
 
 /**

--- a/server/index.ts
+++ b/server/index.ts
@@ -72,9 +72,10 @@ const toSceneGameOver: broadcast["toSceneGameOver"] = (
 };
 
 const showVotingSequence: broadcast["showVotingSequence"] = (
-    votingSequence: string
+    votingSequence: string,
+    randTetros: Array<number>
 ) => {
-    io.sockets.emit("showVotingSequence", votingSequence);
+    io.sockets.emit("showVotingSequence", votingSequence, randTetros);
 };
 
 const hideVotingSequence: broadcast["hideVotingSequence"] = () => {

--- a/server/src/Spectator.ts
+++ b/server/src/Spectator.ts
@@ -25,10 +25,12 @@ export class Spectator {
     private votingInterval!: NodeJS.Timer;
     private broadcastShowVotingSequence: broadcast["showVotingSequence"];
     private broadcastHideVotingSequence: broadcast["hideVotingSequence"];
+    private broadcastVotedTetroToSpawn: broadcast["votedTetroToSpawn"];
 
     constructor(
         showVotingSequenceEvent: broadcast["showVotingSequence"],
-        hideVotingSequenceEvent: broadcast["hideVotingSequence"]
+        hideVotingSequenceEvent: broadcast["hideVotingSequence"],
+        votedTetroToSpawn: broadcast["votedTetroToSpawn"]
     ) {
         this._isFirstRoundVoting = true;
         this._isAcceptingVotes = false;
@@ -46,6 +48,7 @@ export class Spectator {
         this._isGameRunning = false;
         this.broadcastShowVotingSequence = showVotingSequenceEvent;
         this.broadcastHideVotingSequence = hideVotingSequenceEvent;
+        this.broadcastVotedTetroToSpawn = votedTetroToSpawn;
     }
 
     get countdownValue(): number {
@@ -246,7 +249,7 @@ export class Spectator {
                 } else if (this._previouslyVotedOption == "option1") {
                     level.spectatorIncreaseFallRate();
                 } else if (this._previouslyVotedOption == "option2") {
-                    console.log("Spawning in tetromino option 1..."); // FIXME: Need to spawn in a tetromino for the players for 20 seconds.
+                    this.broadcastVotedTetroToSpawn(this._randTetros[0]);
                 }
                 break;
             case "option2":
@@ -259,14 +262,14 @@ export class Spectator {
                 } else if (this._previouslyVotedOption == "option1") {
                     level.spectatorDecreaseFallRate();
                 } else if (this._previouslyVotedOption == "option2") {
-                    console.log("Spawning in tetromino option 2 ..."); // FIXME: Spawn in tetrominos for players for 20 seconds.
+                    this.broadcastVotedTetroToSpawn(this._randTetros[1]);
                 }
                 break;
             case "option3":
                 if (this._isFirstRoundVoting) {
                     console.log("Randomizing player blocks"); // FIXME: Randomize player blocks.
                 } else if (this._previouslyVotedOption == "option2") {
-                    console.log("Spawning in tetromino option 3..."); // FIXME: Spawn in tetrominos for players for 20 seconds.
+                    this.broadcastVotedTetroToSpawn(this._randTetros[2]);
                 }
                 break;
         }

--- a/server/src/broadcast.ts
+++ b/server/src/broadcast.ts
@@ -9,4 +9,5 @@ export interface broadcast {
     hideVotingSequence(): void;
     remainingPlayers(playersNeeded: number): void;
     fallRate(fallRate: number): void;
+    votedTetroToSpawn(type: number): void;
 }

--- a/server/src/broadcast.ts
+++ b/server/src/broadcast.ts
@@ -5,7 +5,7 @@ export interface broadcast {
     toSceneWaitingRoom(): void;
     toSceneGameArena(): void;
     toSceneGameOver(msg: Array<ColoredScore>): void;
-    showVotingSequence(votingSequence: string): void;
+    showVotingSequence(votingSequence: string, randTetros: Array<number>): void;
     hideVotingSequence(): void;
     remainingPlayers(playersNeeded: number): void;
     fallRate(fallRate: number): void;


### PR DESCRIPTION
When spectators vote to select the next block to fall, the server will randomly select 3 tetromino types and allow spectators to vote on them.
A new event votedTetroToSpawn is broadcast out to all users.
When a player receives this event, for the next 20 seconds, all tetrominoes that respawn will be of that specified type.

I've also reverted the delay between generating a voting sequence and making a decision to 12 seconds (it just feels better since it gives that small buffer between voting sequences).