### PR TITLE
Scoreboard values properly reset upon new game

### DIFF
--- a/server/src/Scoreboard.ts
+++ b/server/src/Scoreboard.ts
@@ -1,4 +1,5 @@
 import { PlayerColor } from "common/PlayerAttributes";
+import { PlayerID } from "common/message";
 import { Level } from "./Level";
 import { broadcast } from "./broadcast";
 
@@ -104,23 +105,10 @@ export class Scoreboard {
      * @param value The amount to award the player.
      * @param level The level object. Used to *possibly* increase the level of the game.
      */
-    public incrementScore(playerIndex: number, value: number, level: Level) {
+    public incrementScore(playerIndex: PlayerID, value: number, level: Level) {
         this._accumulatedScore += value;
 
-        switch (playerIndex) {
-            case PlayerColor.Orange:
-                this.scoreMap[PlayerColor.Orange].points += value;
-                break;
-            case PlayerColor.Green:
-                this.scoreMap[PlayerColor.Green].points += value;
-                break;
-            case PlayerColor.Pink:
-                this.scoreMap[PlayerColor.Pink].points += value;
-                break;
-            case PlayerColor.Blue:
-                this.scoreMap[PlayerColor.Blue].points += value;
-                break;
-        }
+        this.scoreMap[playerIndex].points += value;
 
         // Reset the score if the level was incremented.
         if (level.checkUpdateLevel(this._accumulatedScore)) {
@@ -137,35 +125,13 @@ export class Scoreboard {
      * @param currentLevel The current level of the game.
      */
     public decrementScore(
-        playerIndex: number,
+        playerIndex: PlayerID,
         value: number,
         currentLevel: number
     ) {
-        switch (playerIndex) {
-            case PlayerColor.Orange:
-                this.scoreMap[PlayerColor.Orange].points -= value;
-                if (this.scoreMap[PlayerColor.Orange].points <= 0) {
-                    this.scoreMap[PlayerColor.Orange].points = 0;
-                }
-                break;
-            case PlayerColor.Green:
-                this.scoreMap[PlayerColor.Green].points -= value;
-                if (this.scoreMap[PlayerColor.Green].points <= 0) {
-                    this.scoreMap[PlayerColor.Green].points = 0;
-                }
-                break;
-            case PlayerColor.Pink:
-                this.scoreMap[PlayerColor.Pink].points -= value;
-                if (this.scoreMap[PlayerColor.Pink].points <= 0) {
-                    this.scoreMap[PlayerColor.Pink].points = 0;
-                }
-                break;
-            case PlayerColor.Blue:
-                this.scoreMap[PlayerColor.Blue].points -= value;
-                if (this.scoreMap[PlayerColor.Blue].points <= 0) {
-                    this.scoreMap[PlayerColor.Blue].points = 0;
-                }
-                break;
+        this.scoreMap[playerIndex].points -= value;
+        if (this.scoreMap[playerIndex].points <= 0) {
+            this.scoreMap[playerIndex].points = 0;
         }
 
         this.updateScoreboardUI(currentLevel);

--- a/server/src/Scoreboard.ts
+++ b/server/src/Scoreboard.ts
@@ -110,6 +110,7 @@ export class Scoreboard {
         this._blueScore = 0;
         this._accumulatedScore = 0;
         this._finalScores = [];
+        this.updateScoreMap();
     }
 
     /**
@@ -186,7 +187,7 @@ export class Scoreboard {
     }
 
     /**
-     * Update the values of the score map. This is handled separately since it is a sorted array of objects.
+     * Update the values of the score map.
      */
     private updateScoreMap() {
         for (let i = 0; i < this._scoreMap.length; i++) {
@@ -205,11 +206,6 @@ export class Scoreboard {
                     break;
             }
         }
-
-        // Sort in descending order.
-        this._scoreMap.sort((a, b) => {
-            return b.points - a.points;
-        });
     }
 
     /**
@@ -235,6 +231,11 @@ export class Scoreboard {
      */
     public getFinalScores() {
         this.updateScoreMap();
+
+        // Sort in descending order.
+        this._scoreMap.sort((a, b) => {
+            return b.points - a.points;
+        });
 
         this._finalScores = Object.assign([], this._scoreMap);
         this._finalScores.push({

--- a/server/src/Scoreboard.ts
+++ b/server/src/Scoreboard.ts
@@ -10,37 +10,15 @@ type SocketScoreboard = Socket<ToServerEvents, ToClientEvents>;
 
 export class Scoreboard {
     private _accumulatedScore: number;
-    private scoreMap: Array<ColoredScore>;
+    private scoreMap!: Array<ColoredScore>;
     private _finalScores: Array<ColoredScore>;
     private broadcastUpdateScoreboard: broadcast["updateScoreboard"];
 
     constructor(updateScoreboardEvent: broadcast["updateScoreboard"]) {
         this._accumulatedScore = 0;
-
         this.broadcastUpdateScoreboard = updateScoreboardEvent;
-
         this._finalScores = [];
-
-        this.scoreMap = [];
-        this.scoreMap.push({
-            color: "orange",
-            points: 0,
-        });
-
-        this.scoreMap.push({
-            color: "green",
-            points: 0,
-        });
-
-        this.scoreMap.push({
-            color: "pink",
-            points: 0,
-        });
-
-        this.scoreMap.push({
-            color: "blue",
-            points: 0,
-        });
+        this.newScoreMap();
     }
 
     public initSocketListeners(socket: SocketScoreboard, level: Level) {
@@ -86,12 +64,36 @@ export class Scoreboard {
     }
 
     /**
+     * Reset the scoremap & ensure proper ordering of the player->sore. i.e., scoremap[0].points belongs to player orange.
+     */
+    private newScoreMap() {
+        this.scoreMap = [];
+        this.scoreMap.push({
+            color: "orange",
+            points: 0,
+        });
+
+        this.scoreMap.push({
+            color: "green",
+            points: 0,
+        });
+
+        this.scoreMap.push({
+            color: "pink",
+            points: 0,
+        });
+
+        this.scoreMap.push({
+            color: "blue",
+            points: 0,
+        });
+    }
+
+    /**
      * Reset all scores.
      */
     public resetScores() {
-        this.scoreMap.forEach((player) => {
-            player.points = 0;
-        });
+        this.newScoreMap();
         this._accumulatedScore = 0;
         this._finalScores = [];
     }


### PR DESCRIPTION
This PR fixes an issue where the scoreboard HUD didn't reset upon starting a new game. So you may see previous scores from other players still on there.

The issue is related to the _scoreMap and not updating itself to the new values upon restarting the game (it only updated itself when someone gained/lost points).

The scoreboard file has been simplified down a bit so its only dealing with the scoreMap variable rather than individually handling a players scores and then updating the scoreMap.