### PR TITLE
Ignore tradeUI main update for spectators.

### DIFF
--- a/client/src/scene/SceneGameArena.ts
+++ b/client/src/scene/SceneGameArena.ts
@@ -249,6 +249,9 @@ export class SceneGameArena extends Phaser.Scene {
         }
     }
     private updateFromTradeState() {
+        if (this.gameState.playerId == null) {
+            return;
+        }
         this.trade.updateNewTradeState(
             this.gameState.tradeState,
             this.gameState.tradingPlayerId


### PR DESCRIPTION
Stop spectator clients to invoke trade updates which is not initialized and will crash.