### PR TITLE
Fix for corrupted waiting room text

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -132,6 +132,7 @@ const spectator = new Spectator(
 );
 const scene = new SceneTracker();
 const boardSync = new BoardSync(updateBoard);
+let isGameOver: boolean = false;
 
 let watchdogTimer: Watchdog;
 const watchdogFood = {
@@ -140,11 +141,17 @@ const watchdogFood = {
 };
 
 function gameOver() {
+    if (isGameOver) {
+        return;
+    }
+    isGameOver = true;
+
     toSceneGameOver(scoreboard.getFinalScores());
 
     // Return to starting scene after 30 seconds.
     setTimeout(() => {
         toSceneWaitingRoom();
+        isGameOver = false;
     }, 30000);
 }
 


### PR DESCRIPTION
Issue:
![image](https://user-images.githubusercontent.com/45128157/161365788-91955cb0-ba16-4c51-87ec-531c476af222.png)

The problem was occurring because the server received two gameOver events.
I've placed a guard around gameOver() to ensure it's only run once.
