### PR TITLE
Prevent player from moving too far into neighbors.

### DIFF
--- a/client/src/GameState.ts
+++ b/client/src/GameState.ts
@@ -567,7 +567,7 @@ export class GameState {
         }
 
         if (
-            this.enteringNeighborPrivateArea(lookahead) ||
+            this.isInNeighborSection(lookahead) ||
             this.overlapWithBoard(lookahead) ||
             this.overlapWithPlayers(lookahead, this.otherTetrominoes)
         ) {
@@ -578,9 +578,7 @@ export class GameState {
         return true;
     }
 
-    private enteringNeighborPrivateArea(
-        lookahead: TetrominoLookahead
-    ): boolean {
+    private isInNeighborSection(lookahead: TetrominoLookahead): boolean {
         return lookahead.tiles.some(([_, col]) => {
             return (
                 col < PRIVATE_AREA_LENGTH ||

--- a/client/src/GameState.ts
+++ b/client/src/GameState.ts
@@ -1,6 +1,11 @@
 import { Socket } from "socket.io-client";
 
-import { BoardState, BOARD_SIZE, WALL_SIZE } from "common/shared";
+import {
+    BoardState,
+    BOARD_SIZE,
+    PRIVATE_AREA_LENGTH,
+    WALL_SIZE,
+} from "common/shared";
 import { TetrominoType } from "common/TetrominoType";
 import { ToServerEvents, ToClientEvents } from "common/messages/game";
 import { TradeState } from "common/TradeState";
@@ -562,6 +567,7 @@ export class GameState {
         }
 
         if (
+            this.enteringNeighborPrivateArea(lookahead) ||
             this.overlapWithBoard(lookahead) ||
             this.overlapWithPlayers(lookahead, this.otherTetrominoes)
         ) {
@@ -570,6 +576,17 @@ export class GameState {
 
         this.currentTetromino.updateFromLookahead(lookahead);
         return true;
+    }
+
+    private enteringNeighborPrivateArea(
+        lookahead: TetrominoLookahead
+    ): boolean {
+        return lookahead.tiles.some(([_, col]) => {
+            return (
+                col < PRIVATE_AREA_LENGTH ||
+                col >= BOARD_SIZE - PRIVATE_AREA_LENGTH
+            );
+        });
     }
 
     /**

--- a/common/shared.ts
+++ b/common/shared.ts
@@ -1,6 +1,7 @@
 import { TetrominoType } from "./TetrominoType";
 export const BOARD_SIZE = 40;
 export const WALL_SIZE = 15;
+export const PRIVATE_AREA_LENGTH = 8;
 export const TILE_SIZE = 40;
 export const TILE_SCALE = TILE_SIZE / 8;
 export const BOARD_PX = BOARD_SIZE * TILE_SIZE;


### PR DESCRIPTION
create an invisible boundary check to forbid player moving too far left/right into other player's own section. Current limit is as far as 8 blocks away from the generation line.

e.g. the red block can go only as far as that.
![image](https://user-images.githubusercontent.com/25297856/161397825-800dc7b8-8430-4fca-a920-8113ec249d4f.png)
