### PR TITLE
Fix synchronization issue by skipping periodic update on server

### DIFF
--- a/client/src/scene/SceneGameArena.ts
+++ b/client/src/scene/SceneGameArena.ts
@@ -184,6 +184,7 @@ export class SceneGameArena extends Phaser.Scene {
         this.socket.removeListener("toSceneGameOver");
         this.socket.removeListener("updateFallRate");
         this.socket.removeListener("initPlayer");
+        this.socket.removeListener("updateBoard");
 
         this.socket.on("initPlayer", (playerId) => {
             this.trade.addControls(playerId);

--- a/server/index.ts
+++ b/server/index.ts
@@ -213,6 +213,7 @@ io.on("connection", (socket) => {
         if (playerId == null) {
             return;
         }
+        boardSync.updateLastPlacingTS();
         socket.broadcast.emit("playerPlace", playerId, state);
     });
 


### PR DESCRIPTION
## What
This hopefully prevents the edge case where the sync board state
is just one step behind the should-be state after placing but
arrived late and had overwritten the previous should-be state.

## How
server records the timestamp of the latest `playerPlace` event. 

When periodic update is about to broadcast, server checks and ponders:
> Is now too close to the last placing event that I forward to all clients? because if so then my reported state is likely outdated by the new placing event. Let's abort."